### PR TITLE
Reword the group_expiry explanation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,12 @@ get to it.
 ``group_expiry``
 ~~~~~~~~~~~~~~~~
 
-Group expiry in seconds. Defaults to ``86400``. Interface servers will drop
-connections after this amount of time; it's recommended you reduce it for a
-healthier system that encourages disconnections.
+Group expiry in seconds. Defaults to ``86400``. Channels will be removed
+from the group after this amount of time; it's recommended you reduce it
+for a healthier system that encourages disconnections. This value should
+not be lower than the relevant timeouts in the interface server (e.g.
+the ``--websocket_timeout`` to `daphne
+<https://github.com/django/daphne>`_).
 
 ``capacity``
 ~~~~~~~~~~~~


### PR DESCRIPTION
Mention the websocket timeout in daphne. The README recommends lowering
``group_expiry`` but does not mention that websocket timeouts should
also be lowered at the same time. I also had active websocket connections
which did not receive any group message, and had to read the code and
monitor redis to find out the reason for this.

From: https://github.com/django/channels/issues/999#issuecomment-378094611