### PR TITLE
Fixing LUA group send correctness

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -118,12 +118,14 @@ class RedisChannelLayer(BaseChannelLayer):
         # Make sure the message does not contain reserved keys
         assert "__asgi_channel__" not in message
         # If it's a process-local channel, strip off local part and stick full name in message
+
+        channel_non_local_name = channel
         if "!" in channel:
             message = dict(message.items())
             message["__asgi_channel__"] = channel
-            channel = self.non_local_name(channel)
+            channel_non_local_name = self.non_local_name(channel)
         # Write out message into expiring key (avoids big items in list)
-        channel_key = self.prefix + channel
+        channel_key = self.prefix + channel_non_local_name
         # Pick a connection to the right server - consistent for specific
         # channels, random for general channels
         if "!" in channel:

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -312,7 +312,8 @@ class RedisChannelLayer(BaseChannelLayer):
             # Return current lot
             channel_names = [x.decode("utf8") for x in await connection.zrange(key, 0, -1)]
 
-        connection_to_channels, channel_to_message, channel_to_key = self._map_channel_to_connection(channel_names, message)
+        connection_to_channels, channel_to_message, channel_to_key = \
+            self._map_channel_to_connection(channel_names, message)
 
         for connection_index, channel_redis_keys in connection_to_channels.items():
             # Create a LUA script specific for this connection.
@@ -328,7 +329,7 @@ class RedisChannelLayer(BaseChannelLayer):
 
             # We need to filter the messages to keep those related to the connection
             args = [channel_to_message[channel_name] for channel_name in channel_names
-                        if channel_to_key[channel_name] in channel_redis_keys]
+                    if channel_to_key[channel_name] in channel_redis_keys]
 
             async with self.connection(connection_index) as connection:
                 await connection.eval(group_send_lua, keys=channel_redis_keys, args=args)

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -312,9 +312,9 @@ class RedisChannelLayer(BaseChannelLayer):
             # Return current lot
             channel_names = [x.decode("utf8") for x in await connection.zrange(key, 0, -1)]
 
-        connection_to_channels, channel_to_message = self._map_channel_to_connection(channel_names, message)
+        connection_to_channels, channel_to_message, channel_to_key = self._map_channel_to_connection(channel_names, message)
 
-        for connection_index, channel_names in connection_to_channels.items():
+        for connection_index, channel_redis_keys in connection_to_channels.items():
             # Create a LUA script specific for this connection.
             # Make sure to use the message specific to this channel, it is
             # stored in channel_to_message dict and contains the
@@ -326,10 +326,12 @@ class RedisChannelLayer(BaseChannelLayer):
                 end
             """ % self.expiry
 
-            args = [channel_to_message[channel_name] for channel_name in channel_names]
+            # We need to filter the messages to keep those related to the connection
+            args = [channel_to_message[channel_name] for channel_name in channel_names
+                        if channel_to_key[channel_name] in channel_redis_keys]
 
             async with self.connection(connection_index) as connection:
-                await connection.eval(group_send_lua, keys=channel_names, args=args)
+                await connection.eval(group_send_lua, keys=channel_redis_keys, args=args)
 
     def _map_channel_to_connection(self, channel_names, message):
         """
@@ -337,22 +339,27 @@ class RedisChannelLayer(BaseChannelLayer):
         connection index
         Also for each channel create a message specific to that channel, adding
         the __asgi_channel__ key to the message
+        We also return a mapping from channel names to their corresponding Redis
+        keys
         """
         connection_to_channels = collections.defaultdict(list)
         channel_to_message = dict()
+        channel_to_key = dict()
 
         for channel in channel_names:
-
+            channel_non_local_name = channel
             if "!" in channel:
                 message = dict(message.items())
                 message["__asgi_channel__"] = channel
-                channel = self.non_local_name(channel)
-            channel_key = self.prefix + channel
-            idx = self.consistent_hash(channel)
+                channel_non_local_name = self.non_local_name(channel)
+            channel_key = self.prefix + channel_non_local_name
+            idx = self.consistent_hash(channel_non_local_name)
             connection_to_channels[idx].append(channel_key)
-            channel_to_message[channel_key] = self.serialize(message)
+            channel_to_message[channel] = self.serialize(message)
+            # We build a
+            channel_to_key[channel] = channel_key
 
-        return connection_to_channels, channel_to_message
+        return connection_to_channels, channel_to_message, channel_to_key
 
     def _group_key(self, group):
         """

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -118,7 +118,6 @@ class RedisChannelLayer(BaseChannelLayer):
         # Make sure the message does not contain reserved keys
         assert "__asgi_channel__" not in message
         # If it's a process-local channel, strip off local part and stick full name in message
-
         channel_non_local_name = channel
         if "!" in channel:
             message = dict(message.items())

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -230,6 +230,27 @@ async def test_groups_multiple_hosts(channel_layer_multiple_hosts):
             await channel_layer.receive(channel_name2)
 
 
+@pytest.mark.asyncio
+async def test_groups_same_prefix(channel_layer):
+    """
+    Tests group_send with multiple channels with same channel prefix
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS)
+    channel_name1 = await channel_layer.new_channel(prefix="test-gr-chan")
+    channel_name2 = await channel_layer.new_channel(prefix="test-gr-chan")
+    channel_name3 = await channel_layer.new_channel(prefix="test-gr-chan")
+    await channel_layer.group_add("test-group", channel_name1)
+    await channel_layer.group_add("test-group", channel_name2)
+    await channel_layer.group_add("test-group", channel_name3)
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+
+    # Make sure we get the message on the two channels that were in
+    async with async_timeout.timeout(1):
+        assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name2))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name3))["type"] == "message.1"
+
+
 @pytest.mark.parametrize("num_channels,timeout", [
     (1, 1),  # Edge cases - make sure we can send to a single channel
     (10, 1),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -244,7 +244,7 @@ async def test_groups_same_prefix(channel_layer):
     await channel_layer.group_add("test-group", channel_name3)
     await channel_layer.group_send("test-group", {"type": "message.1"})
 
-    # Make sure we get the message on the two channels that were in
+    # Make sure we get the message on the channels that were in
     async with async_timeout.timeout(1):
         assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
         assert (await channel_layer.receive(channel_name2))["type"] == "message.1"


### PR DESCRIPTION
Fixes #93. The LUA version of `group_send` introduced in #85 is now correctly dispatching messages to multiple channels with the same prefix. 

Added a test to avoid this to break in the future.

I also fixed #94 since it was caused by a very similar piece of code.