### PR TITLE
Sending Single Message Per Client Prefix/ User Prefix

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -382,9 +382,8 @@ class RedisChannelLayer(BaseChannelLayer):
 
         1. list of their redis keys bucket each one to a dict keyed by the connection index
 
-        2. for each unique channel redis key create a message specific to that redis key, by adding
-           the comma separated string of channels which maps to that particular redis key
-           in __asgi_channel__ key to the message
+        2. for each unique channel redis key create a serialized message specific to that redis key, by adding
+           the list of channels mapped to that redis key in __asgi_channel__ key to the message
 
         3. returns a mapping of redis channels keys to their capacity
         """


### PR DESCRIPTION
previously for each channel subscribed to a group message was  being pushed  to list stored at channel key. I have grouped those messages by sending list of channels associated with that that channel redis key with a single message  . It saves a great deal of time by reducing the number of push and pops from redis.
Fixes : #7, #83