### PR TITLE
Support additional redis connection parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Possible options for ``CONFIG`` are listed below.
 ``hosts``
 ~~~~~~~~~
 
-The server(s) to connect to, as either URIs or ``(host, port)`` tuples.
+The server(s) to connect to, as either URIs, ``(host, port)`` tuples, or dicts conforming to `create_connection <https://aioredis.readthedocs.io/en/v1.1.0/api_reference.html#aioredis.create_connection>`_.
 Defaults to ``['localhost', 6379]``. Pass multiple hosts to enable sharding,
 but note that changing the host list will lose some sharded data.
 

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -85,9 +85,12 @@ class RedisChannelLayer(BaseChannelLayer):
         # Decode each hosts entry into a kwargs dict
         result = []
         for entry in hosts:
-            result.append({
-                "address": entry,
-            })
+            if isinstance(entry, dict):
+                result.append(entry)
+            else:
+                result.append({
+                    "address": entry,
+                })
         return result
 
     def _setup_encryption(self, symmetric_encryption_keys):


### PR DESCRIPTION
Allow additional aioredis connection parameters to be used in django's settings.py. 

This allows us to use a non-default redis DB number, provide a password, etc.