### PR TITLE
release receive_lock on CancelledError when task.cancel() fails

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -384,8 +384,7 @@ class RedisChannelLayer(BaseChannelLayer):
                         # Ensure all tasks are cancelled if we are cancelled.
                         # Also see: https://bugs.python.org/issue23859
                         for task in tasks:
-                            cancelOK = task.cancel()
-                            if not cancelOK:
+                            if not task.cancel():
                                 assert task.done()
                                 if task.result() is True:
                                     self.receive_lock.release()

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -384,7 +384,11 @@ class RedisChannelLayer(BaseChannelLayer):
                         # Ensure all tasks are cancelled if we are cancelled.
                         # Also see: https://bugs.python.org/issue23859
                         for task in tasks:
-                            task.cancel()
+                            cancelOK = task.cancel()
+                            if not cancelOK:
+                                assert task.done()
+                                if task.result() is True:
+                                    self.receive_lock.release()
 
                         raise
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -321,3 +321,26 @@ async def test_group_send_capacity(channel_layer):
     with pytest.raises(asyncio.TimeoutError):
         async with async_timeout.timeout(1):
             await channel_layer.receive(channel)
+
+@pytest.mark.asyncio
+async def test_receive_cancel(channel_layer):
+    """
+    Makes sure we can cancel a receive without blocking
+    """
+    channel_layer = RedisChannelLayer(capacity=10)
+    channel = await channel_layer.new_channel()
+    delay = 0
+    while delay < 0.01:
+        await channel_layer.send(
+            channel, {"type": "test.message", "text": "Ahoy-hoy!"}
+        )
+
+        task = asyncio.ensure_future(channel_layer.receive(channel))
+        await asyncio.sleep(delay)
+        task.cancel()
+        delay += 0.001
+
+        try:
+            await asyncio.wait_for(task, None)
+        except asyncio.CancelledError:
+            pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -322,6 +322,7 @@ async def test_group_send_capacity(channel_layer):
         async with async_timeout.timeout(1):
             await channel_layer.receive(channel)
 
+
 @pytest.mark.asyncio
 async def test_receive_cancel(channel_layer):
     """
@@ -331,9 +332,7 @@ async def test_receive_cancel(channel_layer):
     channel = await channel_layer.new_channel()
     delay = 0
     while delay < 0.01:
-        await channel_layer.send(
-            channel, {"type": "test.message", "text": "Ahoy-hoy!"}
-        )
+        await channel_layer.send(channel, {"type": "test.message", "text": "Ahoy-hoy!"})
 
         task = asyncio.ensure_future(channel_layer.receive(channel))
         await asyncio.sleep(delay)


### PR DESCRIPTION
This fix resolves the stuck channel layer I bumped into in my AWS production environment.  I've been running there with this fix for several days now (with websocket_timeout=300 to exacerbate the issue) and haven't seen a single ChannelFull exception or self.receive_lock.locked() assertion. 

I posted about my findings in https://github.com/django/channels_redis/issues/134 and I believe the fix also addresses https://github.com/django/channels_redis/issues/136.

The test case I created in test_core.py is a little dubious because it's timing dependent but I'm not sure how else to tickle the race condition.  Suggestions welcome.