### PR TITLE
Clean up receive_buffer. Fixes memory leak.

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -383,6 +383,7 @@ class RedisChannelLayer(BaseChannelLayer):
                     except asyncio.CancelledError:
                         # Ensure all tasks are cancelled if we are cancelled.
                         # Also see: https://bugs.python.org/issue23859
+                        del self.receive_buffer[channel]
                         for task in tasks:
                             if not task.cancel():
                                 assert task.done()
@@ -433,6 +434,9 @@ class RedisChannelLayer(BaseChannelLayer):
                             else:
                                 self.receive_buffer[message_channel].put_nowait(message)
                             message = None
+                        except:
+                            del self.receive_buffer[channel]
+                            return
                         finally:
                             self.receive_lock.release()
 

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -1,5 +1,3 @@
-from builtins import BaseException
-
 import asyncio
 import base64
 import binascii
@@ -436,7 +434,7 @@ class RedisChannelLayer(BaseChannelLayer):
                             else:
                                 self.receive_buffer[message_channel].put_nowait(message)
                             message = None
-                        except BaseException:
+                        except:
                             del self.receive_buffer[channel]
                             raise
                         finally:

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -1,3 +1,5 @@
+from builtins import BaseException
+
 import asyncio
 import base64
 import binascii
@@ -434,9 +436,9 @@ class RedisChannelLayer(BaseChannelLayer):
                             else:
                                 self.receive_buffer[message_channel].put_nowait(message)
                             message = None
-                        except:
+                        except BaseException:
                             del self.receive_buffer[channel]
-                            return
+                            raise
                         finally:
                             self.receive_lock.release()
 


### PR DESCRIPTION
This is fix 2 of 2 for django/channels#1181. Fixes memory leak in receive_buffer.