### PR TITLE
Add 'python_requires' check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires='>=3.5.2',
+    python_requires=">=3.5.2",
     install_requires=[
         "aioredis~=1.0",
         "msgpack~=0.5.2",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
+    python_requires='>=3.5.2',
     install_requires=[
         "aioredis~=1.0",
         "msgpack~=0.5.2",


### PR DESCRIPTION
This will prevent users of Python <3.5.2 from installing the package.