### PR TITLE
Fix double colon in group names.

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -615,9 +615,11 @@ class RedisChannelLayer(BaseChannelLayer):
                 x.decode("utf8") for x in await connection.zrange(key, 0, -1)
             ]
 
-        connection_to_channel_keys, channel_keys_to_message, channel_keys_to_capacity = self._map_channel_keys_to_connection(
-            channel_names, message
-        )
+        (
+            connection_to_channel_keys,
+            channel_keys_to_message,
+            channel_keys_to_capacity,
+        ) = self._map_channel_keys_to_connection(channel_names, message)
 
         for connection_index, channel_redis_keys in connection_to_channel_keys.items():
 
@@ -745,7 +747,7 @@ class RedisChannelLayer(BaseChannelLayer):
         """
         Common function to make the storage key for the group.
         """
-        return ("%s:group:%s" % (self.prefix, group)).encode("utf8")
+        return (self.prefix + "group:" + group).encode("utf8")
 
     ### Serialization ###
 


### PR DESCRIPTION
Remove the extra colon since prefix already contains a colon at the end.

e.g. "asgi::group:ABB47B09AA1C9425"

Tested with my own build. Made sure the extra colon was removed.