### PR TITLE
ConnectionPool.pop must ensure active connections are returned.

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -618,9 +618,11 @@ class RedisChannelLayer(BaseChannelLayer):
                 x.decode("utf8") for x in await connection.zrange(key, 0, -1)
             ]
 
-        connection_to_channel_keys, channel_keys_to_message, channel_keys_to_capacity = self._map_channel_keys_to_connection(
-            channel_names, message
-        )
+        (
+            connection_to_channel_keys,
+            channel_keys_to_message,
+            channel_keys_to_capacity,
+        ) = self._map_channel_keys_to_connection(channel_names, message)
 
         for connection_index, channel_redis_keys in connection_to_channel_keys.items():
 

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -69,6 +69,9 @@ class ConnectionPool:
         if not conns:
             conns.append(await aioredis.create_redis(**self.host, loop=loop))
         conn = conns.pop()
+        if conn.closed:
+            conn = await self.pop(loop=loop)
+            return conn
         self.in_use[conn] = loop
         return conn
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -331,7 +331,7 @@ async def test_connection_pool_pop():
 
     # Setup scenario
     connection_pool = ConnectionPool(TEST_HOSTS[0])
-    conn = connection_pool.pop()
+    conn = await connection_pool.pop()
 
     # Emualte a disconnect and return it to the pool
     await conn.close()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -330,7 +330,7 @@ async def test_connection_pool_pop():
     """
 
     # Setup scenario
-    connection_pool = ConnectionPool(TEST_HOSTS[0])
+    connection_pool = ConnectionPool({'address': TEST_HOSTS[0]})
     conn = await connection_pool.pop()
 
     # Emualte a disconnect and return it to the pool

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,7 +5,7 @@ import pytest
 from async_generator import async_generator, yield_
 
 from asgiref.sync import async_to_sync
-from channels_redis.core import ChannelFull, RedisChannelLayer, ConnectionPool
+from channels_redis.core import ChannelFull, ConnectionPool, RedisChannelLayer
 
 TEST_HOSTS = [("localhost", 6379)]
 
@@ -344,7 +344,7 @@ async def test_connection_pool_pop():
     assert conns[0].closed == True
 
     # Retrieve new connection
-    conn = conn_pool.pop()
+    conn = connection_pool.pop()
     assert conn.closed == False
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -330,7 +330,7 @@ async def test_connection_pool_pop():
     """
 
     # Setup scenario
-    connection_pool = ConnectionPool({'address': TEST_HOSTS[0]})
+    connection_pool = ConnectionPool({"address": TEST_HOSTS[0]})
     conn = await connection_pool.pop()
 
     # Emualte a disconnect and return it to the pool

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -334,12 +334,14 @@ async def test_connection_pool_pop():
     conn = await connection_pool.pop()
 
     # Emualte a disconnect and return it to the pool
-    await conn.close()
+    conn.close()
     assert conn.closed == True
     connection_pool.push(conn)
 
     # Ensure the closed connection is inside the pool
-    conns = list(connection_pool.conn_map.values())
+    conn_map_values = list(connection_pool.conn_map.values())
+    assert len(conn_map_values) == 1
+    conns = conn_map_values[0]
     assert len(conns) == 1
     assert conns[0].closed == True
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -334,7 +334,7 @@ async def test_connection_pool_pop():
     conn = connection_pool.pop()
 
     # Emualte a disconnect and return it to the pool
-    conn.close()
+    await conn.close()
     assert conn.closed == True
     connection_pool.push(conn)
 
@@ -344,7 +344,7 @@ async def test_connection_pool_pop():
     assert conns[0].closed == True
 
     # Retrieve new connection
-    conn = connection_pool.pop()
+    conn = await connection_pool.pop()
     assert conn.closed == False
 
 


### PR DESCRIPTION
Fixes #164