### PR TITLE
Lower logger error on failed group_send from exception to info

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -667,7 +667,7 @@ class RedisChannelLayer(BaseChannelLayer):
                     group_send_lua, keys=channel_redis_keys, args=args
                 )
                 if channels_over_capacity > 0:
-                    logger.exception(
+                    logger.info(
                         f"{channels_over_capacity} of {len(channel_names)} channels over capacity in group {group}"
                     )
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -325,7 +325,7 @@ async def test_group_send_capacity(channel_layer, caplog):
 
     # Make sure number of channels over capacity are logged
     for record in caplog.records:
-        assert record.levelname == "ERROR"
+        assert record.levelname == "INFO"
         assert record.msg == "1 of 1 channels over capacity in group test-group"
 
 
@@ -365,7 +365,7 @@ async def test_group_send_capacity_multiple_channels(channel_layer, caplog):
 
     # Make sure number of channels over capacity are logged
     for record in caplog.records:
-        assert record.levelname == "ERROR"
+        assert record.levelname == "INFO"
         assert record.msg == "1 of 2 channels over capacity in group test-group"
 
 


### PR DESCRIPTION
Lower logger error from exception to info on failed group send to avoid logger spam.

- [x] Covered by tests.