### PR TITLE
Using a sorted set to guarantee message expiration

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,6 +5,10 @@ Unreleased
 
 * Ensured channel names are unique using UUIDs.
 
+* Ensured messages are expired even when channel is in constant activity.
+
+* Optimized Redis script caching
+
 
 2.4.2 (2020-02-19)
 ------------------


### PR DESCRIPTION
Fixes #182 

I went with getrandbits as it generated the 12 random bytes 1 million times in 0.65 seconds against UUID4 that took 3.75 seconds to achieve the same (the difference being UUID4 yields 16 bytes)
I went with 12 bytes to be more memory efficient and still guarantee an astonishing amount of uniqueness.