### PR TITLE
Using UUID4 to guarantee uniqueness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 /.tox
 .DS_Store
 .pytest_cache
+.vscode

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -3,6 +3,8 @@ Unreleased
 
 * Updated msgpack requirement to `~=1.0`.
 
+* Ensured channel names are unique using UUIDs.
+
 
 2.4.2 (2020-02-19)
 ------------------

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -5,11 +5,10 @@ import collections
 import hashlib
 import itertools
 import logging
-import random
-import string
 import sys
 import time
 import types
+import uuid
 
 import aioredis
 import msgpack
@@ -216,10 +215,7 @@ class RedisChannelLayer(BaseChannelLayer):
         self._receive_index_generator = itertools.cycle(range(len(self.hosts)))
         self._send_index_generator = itertools.cycle(range(len(self.hosts)))
         # Decide on a unique client prefix to use in ! sections
-        # TODO: ensure uniqueness better, e.g. Redis keys with SETNX
-        self.client_prefix = "".join(
-            random.choice(string.ascii_letters) for i in range(8)
-        )
+        self.client_prefix = uuid.uuid4().hex
         # Set up any encryption objects
         self._setup_encryption(symmetric_encryption_keys)
         # Number of coroutines trying to receive right now
@@ -533,12 +529,7 @@ class RedisChannelLayer(BaseChannelLayer):
         Returns a new channel name that can be used by something in our
         process as a specific channel.
         """
-        # TODO: Guarantee uniqueness better?
-        return "%s.%s!%s" % (
-            prefix,
-            self.client_prefix,
-            "".join(random.choice(string.ascii_letters) for i in range(12)),
-        )
+        return "%s.%s!%s" % (prefix, self.client_prefix, uuid.uuid4().hex,)
 
     ### Flush extension ###
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
 import asyncio
+import random
 
 import async_timeout
 import pytest
@@ -416,3 +417,31 @@ async def test_receive_cancel(channel_layer):
             await asyncio.wait_for(task, None)
         except asyncio.CancelledError:
             pass
+
+
+@pytest.mark.asyncio
+async def test_random_reset__channel_name(channel_layer):
+    """
+    Makes sure resetting random seed does not make us reuse channel names.
+    """
+
+    channel_layer = RedisChannelLayer()
+    random.seed(1)
+    channel_name_1 = await channel_layer.new_channel()
+    random.seed(1)
+    channel_name_2 = await channel_layer.new_channel()
+
+    assert channel_name_1 != channel_name_2
+
+
+@pytest.mark.asyncio
+async def test_random_reset__client_prefix(channel_layer):
+    """
+    Makes sure resetting random seed does not make us reuse client_prefixes.
+    """
+
+    random.seed(1)
+    channel_layer_1 = RedisChannelLayer()
+    random.seed(1)
+    channel_layer_2 = RedisChannelLayer()
+    assert channel_layer_1.client_prefix != channel_layer_2.client_prefix


### PR DESCRIPTION
From a quick benchmark, UUID4 generated 1 million unique strings in 4.04 seconds and the current implementation took ~7.4 seconds for the same. Fixes #173 