### PR TITLE
Add more check when returning a connection to connection pool

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -82,8 +82,11 @@ class ConnectionPool:
         """
         Return a connection to the pool.
         """
-        loop = self.in_use[conn]
-        del self.in_use[conn]
+        loop = None
+        if conn in self.in_use:
+            loop = self.in_use[conn]
+            del self.in_use[conn]
+
         if loop is not None:
             conns, _ = self._ensure_loop(loop)
             conns.append(conn)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -384,6 +384,13 @@ async def test_connection_pool_pop():
     assert conn.closed == True
     connection_pool.push(conn)
 
+    conn_not_exists = None
+    # Will not return a bad connection to the pool
+    connection_pool.push(conn_not_exists)
+    all_connections_in_this_pool = [conn for conns in connection_pool.conn_map.values()
+                                    for conn in conns]
+    assert conn_not_exists not in all_connections_in_this_pool
+
     # Ensure the closed connection is inside the pool
     conn_map_values = list(connection_pool.conn_map.values())
     assert len(conn_map_values) == 1


### PR DESCRIPTION
If call push method with a connection that created by the pool object, it should not raise a KeyError, so I add some check in the implementation.