### PR TITLE
Bump msgpack to 1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "aioredis~=1.0",
-        "msgpack~=0.6.0",
+        "msgpack>=0.6.0,<1.1",
         "asgiref~=3.0",
         "channels~=2.2",
     ],


### PR DESCRIPTION
According to the changelog most changes are related to dropping Python 2 support. There are also some saner defaults to unpacking that might be relevant:

 * `max_buffer_size` has changed from `0` (aka `INT_MAX`) to `100MB`
 * `strict_map_key` has changed to `True`, which restricts dict keys to `str` or `byte`

Let me know if I should update the calls to msgpack back to the old defaults.

From the [readme](https://github.com/msgpack/msgpack-python#major-breaking-changes-in-msgpack-10):


>* Python 2
>
>    * The extension module does not support Python 2 anymore.
>    The pure Python implementation (`msgpack.fallback`) is used for Python 2.
>
>* Packer
>
>    * `use_bin_type=True` by default.  bytes are encoded in bin type in msgpack.
>    **If you are still using Python 2, you must use unicode for all string types.**
>    You can use `use_bin_type=False` to encode into old msgpack format.
>    * `encoding` option is removed.  UTF-8 is used always.
>
>* Unpacker
>
>    * `raw=False` by default.  It assumes str types are valid UTF-8 string
>    and decode them to Python str (unicode) object.
>    * `encoding` option is removed.  You can use `raw=True` to support old format.
>    * Default value of `max_buffer_size` is changed from 0 to 100 MiB.
>    * Default value of `strict_map_key` is changed to True to avoid hashdos.
>    You need to pass `strict_map_key=False` if you have data which contain map keys
>    which type is not bytes or str.

And full [change log](https://github.com/msgpack/msgpack-python/blob/master/ChangeLog.rst#100):

>1.0.0
>=====
>
>Release Date: 2020-02-17
>
>* Remove Python 2 support from the ``msgpack/_cmsgpack``.
>  ``msgpack/fallback`` still supports Python 2.
>* Remove ``encoding`` option from the Packer and Unpacker.
>* Unpacker: The default value of ``max_buffer_type`` is changed to 100MiB.
>* Unpacker: ``strict_map_key`` is True by default now.
>* Unpacker: String map keys are interned.
>* Drop old buffer protocol support.
>* Support Timestamp type.
>* Support serializing and decerializing ``datetime`` object
>  with tzinfo.
>* Unpacker: ``Fix Unpacker.read_bytes()`` in fallback implementation. (#352)