### PR TITLE
Bump pytest to 5.4.0 to resolve version conflicts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ readme = open(join(dirname(__file__), "README.rst")).read()
 crypto_requires = ["cryptography>=1.3.0"]
 
 test_requires = crypto_requires + [
-    "pytest~=3.6.0",
+    "pytest~=5.4.0",
     "pytest-asyncio~=0.8",
     "async_generator~=1.8",
     "async-timeout~=2.0",


### PR DESCRIPTION
**Summary**
Tests are failing because of version conflict and errors indicate we need to have pytest>=5.4.0. 
If tests pass, this can be merged and failing PRs rebased.
