### PR TITLE
Allow msgpack from v0.6.0 to v1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ readme = open(join(dirname(__file__), "README.rst")).read()
 crypto_requires = ["cryptography>=1.3.0"]
 
 test_requires = crypto_requires + [
-    "pytest~=3.6.0",
-    "pytest-asyncio~=0.8",
+    "pytest<6.0,>=5.4",
+    "pytest-asyncio~=0.12",
     "async_generator~=1.8",
-    "async-timeout~=2.0",
+    "async-timeout<4.0,>=2.0",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     python_requires=">=3.6",
     install_requires=[
         "aioredis~=1.0",
-        "msgpack~=0.6.0",
+        "msgpack<2.0,>=0.6",
         "asgiref~=3.0",
         "channels~=2.2",
     ],


### PR DESCRIPTION
This follows the release of msgpack-python v1.0.0 on 2020-02-27

The most relevant changes are :
  - default max_buffer_size during unpacking was reduced from 2Gb to 100Mo [1]
     - channels_redis uses the default value
     - other limits (string, array, etc.) now follow max_buffer_size instead of having their own (small) defaults [1]
  - maps keys are now strict by default (only string and bytes) [2]
     - channels already specifies Message dicts as having only unicode strings keys
  - datetime with timezone are supported
     - channels does not include datetime in the allowed Message data types

[1] https://github.com/msgpack/msgpack-python/commit/c356035a576c38db5ca232ede07b291087f1b8b2
[2] https://github.com/msgpack/msgpack-python/commit/d8e3cf0563989a660398318a7c788645124e1d8b