### PR TITLE
Use arguments in logging call

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -688,7 +688,10 @@ class RedisChannelLayer(BaseChannelLayer):
                 )
                 if channels_over_capacity > 0:
                     logger.info(
-                        f"{channels_over_capacity} of {len(channel_names)} channels over capacity in group {group}"
+                        "%s of %s channels over capacity in group %s",
+                        channels_over_capacity,
+                        len(channel_names),
+                        group,
                     )
 
     def _map_channel_to_connection(self, channel_names, message):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -357,7 +357,9 @@ async def test_group_send_capacity(channel_layer, caplog):
     # Make sure number of channels over capacity are logged
     for record in caplog.records:
         assert record.levelname == "INFO"
-        assert record.msg == "1 of 1 channels over capacity in group test-group"
+        assert (
+            record.getMessage() == "1 of 1 channels over capacity in group test-group"
+        )
 
 
 @pytest.mark.asyncio
@@ -397,7 +399,9 @@ async def test_group_send_capacity_multiple_channels(channel_layer, caplog):
     # Make sure number of channels over capacity are logged
     for record in caplog.records:
         assert record.levelname == "INFO"
-        assert record.msg == "1 of 2 channels over capacity in group test-group"
+        assert (
+            record.getMessage() == "1 of 2 channels over capacity in group test-group"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This makes it easier for tools like sentry to group similar messages
even when the exact values change