### PR TITLE
Fix for DeprecationWarning in aioredis dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
       install: pip install -U .[tests] black pyflakes isort
       script:
         - pyflakes .
-        - black --check .
+        - black --diff --check .
         - isort --check-only --diff --recursive channels_redis tests
 
     - stage: release


### PR DESCRIPTION
Closes #179.

Cleanup on the history of #180, squashing to two commits. First commit is updating the Travis config to include diff output when checking the code for `black` format. Second commit is the code change that checks versions and omits a deprecated parameter for the versions where that parameter is deprecated.

Props to @edelvalle for doing all the real work, and @carltongibson for doing the original review. Thank you both! Also to @bjd183 for getting the ball rolling. I was starting to develop blindness to the warning reports when I ran tests, it will be great to get back to _not_ ignoring things 😅

As promised over in #180, the steps I took:

1. Forked django/channels_redis and cloned locally.
2. Added edelvalle/channels_redis as a remote with `git remote add edelvalle https://github.com/edelvalle/channels_redis.git`
3. Checked out the original PR branch with `git checkout edelvalle/master`
4. Made my own local branch: `git checkout -b gh-179`
5. Squashed everything down to one commit using `git rebase -i origin/master` and changing all `pick` lines but the first to `s` (for `squash`)
6. Resolved merge conflicts as rebase did a replay of commits; lots of repeats of `git status`, `vim channels_redis/core.py`, `git add .`, `git rebase --continue`.
7. Reset the newly-squashed commit with `git reset HEAD~`.
8. Added the `.gitignore` and `.travis.yml` changes and committed with message.
9. Added `channels_redis/core.py` and committed with message.