### PR TITLE
Removed trailing `:` from default group name prefix.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -11,6 +11,10 @@ Unreleased
 
 * Reduced group_send failure logging level to reduce log noise.
 
+* Removed trailing `:` from default channel layer `prefix` to avoid double
+  `::` in group keys. (You can restore the old default specifying
+  `prefix="asgi:"` if necessary.)
+
 
 2.4.2 (2020-02-19)
 ------------------

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -193,7 +193,7 @@ class RedisChannelLayer(BaseChannelLayer):
     def __init__(
         self,
         hosts=None,
-        prefix="asgi:",
+        prefix="asgi",
         expiry=60,
         group_expiry=86400,
         capacity=100,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -615,3 +615,15 @@ async def test_message_expiry__group_send__one_channel_expires_message(channel_l
     message = await channel_layer.receive(channel_2)
     assert message["type"] == "test.message"
     assert message["text"] == "Third!"
+
+
+def test_default_group_key_format():
+    channel_layer = RedisChannelLayer()
+    group_name = channel_layer._group_key("test_group")
+    assert group_name == b"asgi:group:test_group"
+
+
+def test_custom_group_key_format():
+    channel_layer = RedisChannelLayer(prefix="test_prefix")
+    group_name = channel_layer._group_key("test_group")
+    assert group_name == b"test_prefix:group:test_group"


### PR DESCRIPTION
Closes #177.