### PR TITLE
Update 3.0.0 changelog entry to note redis version

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -16,8 +16,8 @@
 * Removed trailing `:` from default channel layer `prefix` to avoid double
   `::` in group keys. (You can restore the old default specifying
   `prefix="asgi:"` if necessary.)
-  
-  
+
+
 2.4.2 (2020-02-19)
 ------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,8 @@
 3.0.0 (2020-07-03)
 ------------------
 
+* Redis >= 5.0 is now required.
+
 * Updated msgpack requirement to `~=1.0`.
 
 * Ensured channel names are unique using UUIDs.
@@ -15,9 +17,7 @@
   `::` in group keys. (You can restore the old default specifying
   `prefix="asgi:"` if necessary.)
   
-* BREAKING CHANGE: Redis >= 5.0 is now required.
-
-
+  
 2.4.2 (2020-02-19)
 ------------------
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -14,6 +14,8 @@
 * Removed trailing `:` from default channel layer `prefix` to avoid double
   `::` in group keys. (You can restore the old default specifying
   `prefix="asgi:"` if necessary.)
+  
+* BREAKING CHANGE: Redis >= 5.0 is now required.
 
 
 2.4.2 (2020-02-19)


### PR DESCRIPTION
3.0.0 introduces a breaking change requiring redis >= 5.0. This should be noted so anyone reviewing changes will know it's a breaking change. The README was updated but the changelog was not.