### PR TITLE
Fix bad call to ZADD in lua script

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,8 @@
+UNRELEASED
+----------
+
+* Fixed error in Lua script introduced in 3.0.0.
+
 3.0.0 (2020-07-03)
 ------------------
 

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -330,9 +330,9 @@ class RedisChannelLayer(BaseChannelLayer):
         # of the main message queue in the proper order; BRPOP must *not* be called
         # because that would deadlock the server
         cleanup_script = """
-            local backed_up = redis.call('ZRANGE', ARGV[2], 0, -1)
-            for i = #backed_up, 1, -1 do
-                redis.call('ZADD', ARGV[1], backed_up[i])
+            local backed_up = redis.call('ZRANGE', ARGV[2], 0, -1, 'WITHSCORES')
+            for i = #backed_up, 1, -2 do
+                redis.call('ZADD', ARGV[1], backed_up[i], backed_up[i - 1])
             end
             redis.call('DEL', ARGV[2])
         """

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -445,7 +445,7 @@ async def test_receive_cancel(channel_layer):
         task = asyncio.ensure_future(channel_layer.receive(channel))
         await asyncio.sleep(delay)
         task.cancel()
-        delay += 0.001
+        delay += 0.0001
 
         try:
             await asyncio.wait_for(task, None)


### PR DESCRIPTION
This bad ZADD call slipped through because the `delay` increment in `test_receive_cancel` was too high, not triggering any elements in the backup queue. Dropping the delay in the test seems to trigger that code path reliably (I observed it only once before with the old value).

Fixes #208.