### PR TITLE
respect channel layer capacity in RedisChannelLayer.receive_buffer

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+UNRELEASED
+----------
+
+* Ensured per-channel queues are bounded in size to avoid a slow memory leak
+  if consumers stop reading.
+
 3.0.1 (2020-07-15)
 ------------------
 


### PR DESCRIPTION
cc @carltongibson 

respect the capacity setting so that the receive_buffer does not grow
without bounds (which can lead to a memory leak)

see: https://github.com/django/channels_redis/issues/212

based on the idea outlined here:

https://github.com/django/channels/issues/1361#issuecomment-672926804

> I'd argue that these per-channel Queue objects should probably be bound in size. There's already a capacity argument; maybe the per-channel buffer should respect that, and only buffer up to that many objects before dropping old ones?