### PR TITLE
Added a list of redis commands, much like the celery RedisBackend

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -18,6 +18,11 @@ import msgpack
 from channels.exceptions import ChannelFull
 from channels.layers import BaseChannelLayer
 
+#
+# It makes use of the following redis commands:
+# ADD, DEL, EVAL, EXPIRE, KEYS, ZADD, ZCOUNT, ZPOPMIN, ZRANGE, ZREM, ZREMRANGEBYSCORE
+#
+
 logger = logging.getLogger(__name__)
 
 AIOREDIS_VERSION = tuple(map(int, aioredis.__version__.split(".")))


### PR DESCRIPTION
This is intended to "fix" issue #226. I've taken some time to find the obvious redis commands, but I'm not sure if this is the complete list.