### PR TITLE
ValueError: int is not allowed for map key when using msgpack 1.0.0

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -828,7 +828,7 @@ class RedisChannelLayer(BaseChannelLayer):
 
         if self.crypter:
             message = self.crypter.decrypt(message, self.expiry + 10)
-        return msgpack.unpackb(message, raw=False)
+        return msgpack.unpackb(message, strict_map_key=False)
 
     ### Internal functions ###
 


### PR DESCRIPTION
**Bug**:
"ValueError: int is not allowed for map key" will be raised when using msgpack 1.0.0 for some messages

**Explanation**:
This is to the fact that they changed their default setting for msgpack.unpackb see: msgpack/msgpack-python#411 which they also discuss as major braking points in https://github.com/msgpack/msgpack-python#major-breaking-changes-in-msgpack-10

**Solution**:
adding strict_map_key=False as argument whenever msgpack.unpackb or msgpack.loads is called


so mainly solution I take from https://github.com/pupil-labs/pupil/issues/1830