### PR TITLE
misc: use faster dictionary operations

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -776,7 +776,7 @@ class RedisChannelLayer(BaseChannelLayer):
             # Get its redis key
             channel_key = self.prefix + channel_non_local_name
             # Have we come across the same redis key?
-            if channel_key not in channel_key_to_message.keys():
+            if channel_key not in channel_key_to_message:
                 # If not, fill the corresponding dicts
                 message = dict(message.items())
                 message["__asgi_channel__"] = [channel]
@@ -789,9 +789,9 @@ class RedisChannelLayer(BaseChannelLayer):
                 channel_key_to_message[channel_key]["__asgi_channel__"].append(channel)
 
         # Now that we know what message needs to be send on a redis key we serialize it
-        for key in channel_key_to_message.keys():
+        for key, value in channel_key_to_message.items():
             # Serialize the message stored for each redis key
-            channel_key_to_message[key] = self.serialize(channel_key_to_message[key])
+            channel_key_to_message[key] = self.serialize(value)
 
         return (
             connection_to_channel_keys,


### PR DESCRIPTION
This is just a pair of microoptimizations for dictionary access in the code:

- check `in dict` is faster than `in dict.keys()`
- iterating through `.items()` with both key and value is faster than iterating through `.keys()` and then lookup the value later through `key`

here's a quick `timeit` benchmark. The `.items()` difference is almost negligible, but changing the `in dict.keys()` is about three times faster now.

```
# test_items.py
import timeit

dict_setup = """channel_key_to_message = {str(x): x for x in range(100)}
def serialize(value): return str(value)"""

dict_items = """for key, value in channel_key_to_message.items(): channel_key_to_message[key] = serialize(value)"""
dict_keys = """for key in channel_key_to_message.keys(): channel_key_to_message[key] = serialize(channel_key_to_message[key])"""

res = timeit.timeit(stmt=dict_items, setup=dict_setup, number=500000)
print('items', res)

res = timeit.timeit(stmt=dict_keys, setup=dict_setup, number=500000)
print('keys', res)


in_dict = '''if "foo" in channel_key_to_message: pass'''
in_keys = '''if "foo" in channel_key_to_message.keys(): pass'''

res = timeit.timeit(stmt=in_dict, setup=dict_setup)
print('in dict', res)

res = timeit.timeit(stmt=in_keys, setup=dict_setup)
print('in keys', res)
```

```
$ python ./test_items.py
items 5.479676875
keys 5.883921375000001
in dict 0.0138149159999994
in keys 0.04116745799999855
```



