### PR TITLE
Don't declare wheels as universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,3 @@
-[bdist_wheel]
-universal=1
-
 [tool:pytest]
 addopts = -p no:django tests/
 


### PR DESCRIPTION
That's intended for wheels that support both Python 2 and 3.