### PR TITLE
remove strict_map_key requirement for deserialize

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -828,7 +828,7 @@ class RedisChannelLayer(BaseChannelLayer):
 
         if self.crypter:
             message = self.crypter.decrypt(message, self.expiry + 10)
-        return msgpack.unpackb(message, raw=False)
+        return msgpack.unpackb(message, raw=False, strict_map_key=False)
 
     ### Internal functions ###
 


### PR DESCRIPTION
Trying to send a dict with integer keys, 
e.g.
```
async_to_sync(channel_layer.group_send)(
        "name",
        {"type":"test",
        "data": {1:10, 2:20},
        }
```
I got 
```
  File "msgpack/_unpacker.pyx", line 195, in msgpack._cmsgpack.unpackb
ValueError: int is not allowed for map key
```
not familiar with the channels or redis code to know if there will be implementations else where; is it safe to relax the checking in  msgpack unpacking with strict_map_key=False ?
