### PR TITLE
RFC - use aioredis pools

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -120,8 +120,9 @@ class ConnectionPool:
                 self.sentinel_map[conn].close()
                 await self.sentinel_map[conn].wait_closed()
                 del self.sentinel_map[conn]
-            conn.close()
-            await conn.wait_closed()
+            else:
+                conn.close()
+                await conn.wait_closed()
             del self.conn_map[loop]
 
     async def close(self):


### PR DESCRIPTION
Hi all - had some time this weekend to re-evaluate getting sentinel support in here after a false start a couple weeks back. After going through aioredis in more detail, it struck me that the easiest approach forward is to hand off the pool orchestration to the native pool handlers.

I'm far from an expert in either of these libraries, so this is more of an RFC than a concrete PR. But it strikes me that having a native pool per loop and letting the underlying library manage the rest is probably the cleanest approach. It also allows sentinel compatibility without having to manage connection/sentinel relationships.