### PR TITLE
redis sentinel support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,6 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
-
     services:
       redis:
         image: redis
@@ -29,6 +28,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      sentinel:
+        image: bitnami/redis-sentinel
+        ports:
+          - 26379:26379
+        options: >-
+          --health-cmd "redis-cli -p 26379 ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        env:
+          REDIS_MASTER_HOST: redis
+          REDIS_MASTER_SET: sentinel
+          REDIS_SENTINEL_QUORUM: "1"
 
     steps:
       - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,9 @@ The server(s) to connect to, as either URIs, ``(host, port)`` tuples, or dicts c
 Defaults to ``['localhost', 6379]``. Pass multiple hosts to enable sharding,
 but note that changing the host list will lose some sharded data.
 
+Sentinel connections require dicts conforming to `create_sentinel <https://aioredis.readthedocs.io/en/v1.3.0/sentinel.html#aioredis.sentinel.create_sentinel>` with an additional `master_name` key specifying the Sentinel master set.
+Vanilla Redis and Sentinel connections can be mixed and matched if sharding.
+
 If your server is listening on a UNIX domain socket, you can also use that to connect: ``["unix:///path/to/redis.sock"]``.
 This should be slightly faster than a loopback TCP connection.
 

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -43,14 +43,15 @@ def _wrap_close(loop, pool):
 class ConnectionPool:
     """
     Connection pool manager for the channel layer.
-
     It manages a set of connections for the given host specification and
     taking into account asyncio event loops.
     """
 
     def __init__(self, host):
-        self.host = host
+        self.host = host.copy()
+        self.master_name = self.host.pop("master_name", None)
         self.conn_map = {}
+        self.sentinel_map = {}
         self.in_use = {}
 
     def _ensure_loop(self, loop):
@@ -68,16 +69,27 @@ class ConnectionPool:
 
         return self.conn_map[loop], loop
 
+    async def create_conn(self, loop):
+        # One connection per pool since we are emulating a single connection
+        kwargs = {"minsize": 1, "maxsize": 1, **self.host}
+        if not (sys.version_info >= (3, 8, 0) and AIOREDIS_VERSION >= (1, 3, 1)):
+            kwargs["loop"] = loop
+        if self.master_name is None:
+            return await aioredis.create_redis_pool(**kwargs)
+        else:
+            kwargs = {"timeout": 2, **kwargs}  # aioredis default is way too low
+            sentinel = await aioredis.sentinel.create_sentinel(**kwargs)
+            conn = sentinel.master_for(self.master_name)
+            self.sentinel_map[conn] = sentinel
+            return conn
+
     async def pop(self, loop=None):
         """
         Get a connection for the given identifier and loop.
         """
         conns, loop = self._ensure_loop(loop)
         if not conns:
-            if sys.version_info >= (3, 8, 0) and AIOREDIS_VERSION >= (1, 3, 1):
-                conn = await aioredis.create_redis(**self.host)
-            else:
-                conn = await aioredis.create_redis(**self.host, loop=loop)
+            conn = await self.create_conn(loop)
             conns.append(conn)
         conn = conns.pop()
         if conn.closed:
@@ -96,11 +108,11 @@ class ConnectionPool:
             conns, _ = self._ensure_loop(loop)
             conns.append(conn)
 
-    def conn_error(self, conn):
+    async def conn_error(self, conn):
         """
         Handle a connection that produced an error.
         """
-        conn.close()
+        await self._close_conn(conn)
         del self.in_use[conn]
 
     def reset(self):
@@ -108,7 +120,18 @@ class ConnectionPool:
         Clear all connections from the pool.
         """
         self.conn_map = {}
+        self.sentinel_map = {}
         self.in_use = {}
+
+    async def _close_conn(self, conn, sentinel_map=None):
+        if sentinel_map is None:
+            sentinel_map = self.sentinel_map
+        if conn in sentinel_map:
+            sentinel_map[conn].close()
+            await sentinel_map[conn].wait_closed()
+            del sentinel_map[conn]
+        conn.close()
+        await conn.wait_closed()
 
     async def close_loop(self, loop):
         """
@@ -116,12 +139,12 @@ class ConnectionPool:
         """
         if loop in self.conn_map:
             for conn in self.conn_map[loop]:
-                conn.close()
-                await conn.wait_closed()
+                await self._close_conn(conn)
             del self.conn_map[loop]
 
         for k, v in self.in_use.items():
             if v is loop:
+                await self._close_conn(k)
                 self.in_use[k] = None
 
     async def close(self):
@@ -129,15 +152,14 @@ class ConnectionPool:
         Close all connections owned by the pool.
         """
         conn_map = self.conn_map
+        sentinel_map = self.sentinel_map
         in_use = self.in_use
         self.reset()
         for conns in conn_map.values():
             for conn in conns:
-                conn.close()
-                await conn.wait_closed()
+                await self._close_conn(conn, sentinel_map)
         for conn in in_use:
-            conn.close()
-            await conn.wait_closed()
+            await self._close_conn(conn, sentinel_map)
 
 
 class ChannelLock:
@@ -262,6 +284,7 @@ class RedisChannelLayer(BaseChannelLayer):
             raise ValueError(
                 "You must pass a list of Redis hosts, even if there is only one."
             )
+
         # Decode each hosts entry into a kwargs dict
         result = []
         for entry in hosts:
@@ -888,7 +911,7 @@ class RedisChannelLayer(BaseChannelLayer):
 
         async def __aexit__(self, exc_type, exc, tb):
             if exc:
-                self.pool.conn_error(self.conn)
+                await self.pool.conn_error(self.conn)
             else:
                 self.pool.push(self.conn)
             self.conn = None

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ crypto_requires = ["cryptography>=1.3.0"]
 
 test_requires = crypto_requires + [
     "pytest",
-    "pytest-asyncio",
+    "pytest-asyncio==0.14.0",
     "async_generator",
     "async-timeout",
 ]

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,0 +1,648 @@
+import asyncio
+import random
+
+import async_timeout
+import pytest
+from async_generator import async_generator, yield_
+
+from asgiref.sync import async_to_sync
+from channels_redis.core import ChannelFull, ConnectionPool, RedisChannelLayer
+
+SENTINEL_MASTER = "sentinel"
+TEST_HOSTS = [{"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER}]
+
+MULTIPLE_TEST_HOSTS = [
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 0},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 1},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 2},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 3},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 4},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 5},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 6},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 7},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 8},
+    {"sentinels": [("localhost", 26379)], "master_name": SENTINEL_MASTER, "db": 9},
+]
+
+
+async def send_three_messages_with_delay(channel_name, channel_layer, delay):
+    await channel_layer.send(channel_name, {"type": "test.message", "text": "First!"})
+
+    await asyncio.sleep(delay)
+
+    await channel_layer.send(channel_name, {"type": "test.message", "text": "Second!"})
+
+    await asyncio.sleep(delay)
+
+    await channel_layer.send(channel_name, {"type": "test.message", "text": "Third!"})
+
+
+async def group_send_three_messages_with_delay(group_name, channel_layer, delay):
+    await channel_layer.group_send(
+        group_name, {"type": "test.message", "text": "First!"}
+    )
+
+    await asyncio.sleep(delay)
+
+    await channel_layer.group_send(
+        group_name, {"type": "test.message", "text": "Second!"}
+    )
+
+    await asyncio.sleep(delay)
+
+    await channel_layer.group_send(
+        group_name, {"type": "test.message", "text": "Third!"}
+    )
+
+
+@pytest.fixture()
+@async_generator
+async def channel_layer():
+    """
+    Channel layer fixture that flushes automatically.
+    """
+    channel_layer = RedisChannelLayer(
+        hosts=TEST_HOSTS,
+        capacity=3,
+        channel_capacity={"tiny": 1},
+    )
+    await yield_(channel_layer)
+    await channel_layer.flush()
+
+
+@pytest.fixture()
+@async_generator
+async def channel_layer_multiple_hosts():
+    """
+    Channel layer fixture that flushes automatically.
+    """
+    channel_layer = RedisChannelLayer(hosts=MULTIPLE_TEST_HOSTS, capacity=3)
+    await yield_(channel_layer)
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_send_receive(channel_layer):
+    """
+    Makes sure we can send a message to a normal channel then receive it.
+    """
+    await channel_layer.send(
+        "test-channel-1", {"type": "test.message", "text": "Ahoy-hoy!"}
+    )
+    message = await channel_layer.receive("test-channel-1")
+    assert message["type"] == "test.message"
+    assert message["text"] == "Ahoy-hoy!"
+
+
+@pytest.mark.parametrize("channel_layer", [None])  # Fixture can't handle sync
+def test_double_receive(channel_layer):
+    """
+    Makes sure we can receive from two different event loops using
+    process-local channel names.
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS, capacity=3)
+
+    # Aioredis connections can't be used from different event loops, so
+    # send and close need to be done in the same async_to_sync call.
+    async def send_and_close(*args, **kwargs):
+        await channel_layer.send(*args, **kwargs)
+        await channel_layer.close_pools()
+
+    channel_name_1 = async_to_sync(channel_layer.new_channel)()
+    channel_name_2 = async_to_sync(channel_layer.new_channel)()
+    async_to_sync(send_and_close)(channel_name_1, {"type": "test.message.1"})
+    async_to_sync(send_and_close)(channel_name_2, {"type": "test.message.2"})
+
+    # Make things to listen on the loops
+    async def listen1():
+        message = await channel_layer.receive(channel_name_1)
+        assert message["type"] == "test.message.1"
+        await channel_layer.close_pools()
+
+    async def listen2():
+        message = await channel_layer.receive(channel_name_2)
+        assert message["type"] == "test.message.2"
+        await channel_layer.close_pools()
+
+    # Run them inside threads
+    async_to_sync(listen2)()
+    async_to_sync(listen1)()
+    # Clean up
+    async_to_sync(channel_layer.flush)()
+
+
+@pytest.mark.asyncio
+async def test_send_capacity(channel_layer):
+    """
+    Makes sure we get ChannelFull when we hit the send capacity
+    """
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    await channel_layer.send("test-channel-1", {"type": "test.message"})
+    with pytest.raises(ChannelFull):
+        await channel_layer.send("test-channel-1", {"type": "test.message"})
+
+
+@pytest.mark.asyncio
+async def test_send_specific_capacity(channel_layer):
+    """
+    Makes sure we get ChannelFull when we hit the send capacity on a specific channel
+    """
+    custom_channel_layer = RedisChannelLayer(
+        hosts=TEST_HOSTS,
+        capacity=3,
+        channel_capacity={"one": 1},
+    )
+    await custom_channel_layer.send("one", {"type": "test.message"})
+    with pytest.raises(ChannelFull):
+        await custom_channel_layer.send("one", {"type": "test.message"})
+    await custom_channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_process_local_send_receive(channel_layer):
+    """
+    Makes sure we can send a message to a process-local channel then receive it.
+    """
+    channel_name = await channel_layer.new_channel()
+    await channel_layer.send(
+        channel_name, {"type": "test.message", "text": "Local only please"}
+    )
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Local only please"
+
+
+@pytest.mark.asyncio
+async def test_multi_send_receive(channel_layer):
+    """
+    Tests overlapping sends and receives, and ordering.
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS)
+    await channel_layer.send("test-channel-3", {"type": "message.1"})
+    await channel_layer.send("test-channel-3", {"type": "message.2"})
+    await channel_layer.send("test-channel-3", {"type": "message.3"})
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.1"
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.2"
+    assert (await channel_layer.receive("test-channel-3"))["type"] == "message.3"
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_reject_bad_channel(channel_layer):
+    """
+    Makes sure sending/receiving on an invalic channel name fails.
+    """
+    with pytest.raises(TypeError):
+        await channel_layer.send("=+135!", {"type": "foom"})
+    with pytest.raises(TypeError):
+        await channel_layer.receive("=+135!")
+
+
+@pytest.mark.asyncio
+async def test_reject_bad_client_prefix(channel_layer):
+    """
+    Makes sure receiving on a non-prefixed local channel is not allowed.
+    """
+    with pytest.raises(AssertionError):
+        await channel_layer.receive("not-client-prefix!local_part")
+
+
+@pytest.mark.asyncio
+async def test_groups_basic(channel_layer):
+    """
+    Tests basic group operation.
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS)
+    channel_name1 = await channel_layer.new_channel(prefix="test-gr-chan-1")
+    channel_name2 = await channel_layer.new_channel(prefix="test-gr-chan-2")
+    channel_name3 = await channel_layer.new_channel(prefix="test-gr-chan-3")
+    await channel_layer.group_add("test-group", channel_name1)
+    await channel_layer.group_add("test-group", channel_name2)
+    await channel_layer.group_add("test-group", channel_name3)
+    await channel_layer.group_discard("test-group", channel_name2)
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    # Make sure we get the message on the two channels that were in
+    async with async_timeout.timeout(1):
+        assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name3))["type"] == "message.1"
+    # Make sure the removed channel did not get the message
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_name2)
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_groups_channel_full(channel_layer):
+    """
+    Tests that group_send ignores ChannelFull
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS)
+    await channel_layer.group_add("test-group", "test-gr-chan-1")
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_groups_multiple_hosts(channel_layer_multiple_hosts):
+    """
+    Tests advanced group operation with multiple hosts.
+    """
+    channel_layer = RedisChannelLayer(hosts=MULTIPLE_TEST_HOSTS, capacity=100)
+    channel_name1 = await channel_layer.new_channel(prefix="channel1")
+    channel_name2 = await channel_layer.new_channel(prefix="channel2")
+    channel_name3 = await channel_layer.new_channel(prefix="channel3")
+    await channel_layer.group_add("test-group", channel_name1)
+    await channel_layer.group_add("test-group", channel_name2)
+    await channel_layer.group_add("test-group", channel_name3)
+    await channel_layer.group_discard("test-group", channel_name2)
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+
+    # Make sure we get the message on the two channels that were in
+    async with async_timeout.timeout(1):
+        assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name3))["type"] == "message.1"
+
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_name2)
+
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_groups_same_prefix(channel_layer):
+    """
+    Tests group_send with multiple channels with same channel prefix
+    """
+    channel_layer = RedisChannelLayer(hosts=TEST_HOSTS)
+    channel_name1 = await channel_layer.new_channel(prefix="test-gr-chan")
+    channel_name2 = await channel_layer.new_channel(prefix="test-gr-chan")
+    channel_name3 = await channel_layer.new_channel(prefix="test-gr-chan")
+    await channel_layer.group_add("test-group", channel_name1)
+    await channel_layer.group_add("test-group", channel_name2)
+    await channel_layer.group_add("test-group", channel_name3)
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+
+    # Make sure we get the message on the channels that were in
+    async with async_timeout.timeout(1):
+        assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name2))["type"] == "message.1"
+        assert (await channel_layer.receive(channel_name3))["type"] == "message.1"
+
+    await channel_layer.flush()
+
+
+@pytest.mark.parametrize(
+    "num_channels,timeout",
+    [
+        (1, 1),  # Edge cases - make sure we can send to a single channel
+        (10, 1),
+        (100, 10),
+    ],
+)
+@pytest.mark.asyncio
+async def test_groups_multiple_hosts_performance(
+    channel_layer_multiple_hosts, num_channels, timeout
+):
+    """
+    Tests advanced group operation: can send efficiently to multiple channels
+    with multiple hosts within a certain timeout
+    """
+    channel_layer = RedisChannelLayer(hosts=MULTIPLE_TEST_HOSTS, capacity=100)
+
+    channels = []
+    for i in range(0, num_channels):
+        channel = await channel_layer.new_channel(prefix="channel%s" % i)
+        await channel_layer.group_add("test-group", channel)
+        channels.append(channel)
+
+    async with async_timeout.timeout(timeout):
+        await channel_layer.group_send("test-group", {"type": "message.1"})
+
+    # Make sure we get the message all the channels
+    async with async_timeout.timeout(timeout):
+        for channel in channels:
+            assert (await channel_layer.receive(channel))["type"] == "message.1"
+
+    await channel_layer.flush()
+
+
+@pytest.mark.asyncio
+async def test_group_send_capacity(channel_layer, caplog):
+    """
+    Makes sure we dont group_send messages to channels that are over capacity.
+    Make sure number of channels with full capacity are logged as an exception to help debug errors.
+    """
+
+    channel = await channel_layer.new_channel()
+    await channel_layer.group_add("test-group", channel)
+
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.2"})
+    await channel_layer.group_send("test-group", {"type": "message.3"})
+    await channel_layer.group_send("test-group", {"type": "message.4"})
+
+    # We should receive the first 3 messages
+    assert (await channel_layer.receive(channel))["type"] == "message.1"
+    assert (await channel_layer.receive(channel))["type"] == "message.2"
+    assert (await channel_layer.receive(channel))["type"] == "message.3"
+
+    # Make sure we do NOT receive message 4
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel)
+
+    # Make sure number of channels over capacity are logged
+    for record in caplog.records:
+        assert record.levelname == "INFO"
+        assert (
+            record.getMessage() == "1 of 1 channels over capacity in group test-group"
+        )
+
+
+@pytest.mark.asyncio
+async def test_group_send_capacity_multiple_channels(channel_layer, caplog):
+    """
+    Makes sure we dont group_send messages to channels that are over capacity
+    Make sure number of channels with full capacity are logged as an exception to help debug errors.
+    """
+
+    channel_1 = await channel_layer.new_channel()
+    channel_2 = await channel_layer.new_channel(prefix="channel_2")
+    await channel_layer.group_add("test-group", channel_1)
+    await channel_layer.group_add("test-group", channel_2)
+
+    # Let's put channel_2 over capacity
+    await channel_layer.send(channel_2, {"type": "message.0"})
+
+    await channel_layer.group_send("test-group", {"type": "message.1"})
+    await channel_layer.group_send("test-group", {"type": "message.2"})
+    await channel_layer.group_send("test-group", {"type": "message.3"})
+
+    # Channel_1 should receive all 3 group messages
+    assert (await channel_layer.receive(channel_1))["type"] == "message.1"
+    assert (await channel_layer.receive(channel_1))["type"] == "message.2"
+    assert (await channel_layer.receive(channel_1))["type"] == "message.3"
+
+    # Channel_2 should receive the first message + 2 group messages
+    assert (await channel_layer.receive(channel_2))["type"] == "message.0"
+    assert (await channel_layer.receive(channel_2))["type"] == "message.1"
+    assert (await channel_layer.receive(channel_2))["type"] == "message.2"
+
+    # Make sure channel_2 does not receive the 3rd group message
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_2)
+
+    # Make sure number of channels over capacity are logged
+    for record in caplog.records:
+        assert record.levelname == "INFO"
+        assert (
+            record.getMessage() == "1 of 2 channels over capacity in group test-group"
+        )
+
+
+@pytest.mark.asyncio
+async def test_connection_pool_pop():
+    """
+    Makes sure that the connection pool does not return closed connections
+    """
+
+    # Setup scenario
+    connection_pool = ConnectionPool(TEST_HOSTS[0])
+    conn = await connection_pool.pop()
+
+    # Emualte a disconnect and return it to the pool
+    conn.close()
+    assert conn.closed
+    connection_pool.push(conn)
+
+    # Ensure the closed connection is inside the pool
+    conn_map_values = list(connection_pool.conn_map.values())
+    assert len(conn_map_values) == 1
+    conns = conn_map_values[0]
+    assert len(conns) == 1
+    assert conns[0].closed
+
+    # Retrieve new connection
+    conn = await connection_pool.pop()
+    assert not conn.closed
+
+
+@pytest.mark.asyncio
+async def test_receive_cancel(channel_layer):
+    """
+    Makes sure we can cancel a receive without blocking
+    """
+    channel_layer = RedisChannelLayer(capacity=10)
+    channel = await channel_layer.new_channel()
+    delay = 0
+    while delay < 0.01:
+        await channel_layer.send(channel, {"type": "test.message", "text": "Ahoy-hoy!"})
+
+        task = asyncio.ensure_future(channel_layer.receive(channel))
+        await asyncio.sleep(delay)
+        task.cancel()
+        delay += 0.0001
+
+        try:
+            await asyncio.wait_for(task, None)
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_random_reset__channel_name(channel_layer):
+    """
+    Makes sure resetting random seed does not make us reuse channel names.
+    """
+
+    channel_layer = RedisChannelLayer()
+    random.seed(1)
+    channel_name_1 = await channel_layer.new_channel()
+    random.seed(1)
+    channel_name_2 = await channel_layer.new_channel()
+
+    assert channel_name_1 != channel_name_2
+
+
+@pytest.mark.asyncio
+async def test_random_reset__client_prefix(channel_layer):
+    """
+    Makes sure resetting random seed does not make us reuse client_prefixes.
+    """
+
+    random.seed(1)
+    channel_layer_1 = RedisChannelLayer()
+    random.seed(1)
+    channel_layer_2 = RedisChannelLayer()
+    assert channel_layer_1.client_prefix != channel_layer_2.client_prefix
+
+
+@pytest.mark.asyncio
+async def test_message_expiry__earliest_message_expires(channel_layer):
+    expiry = 3
+    delay = 2
+    channel_layer = RedisChannelLayer(expiry=expiry)
+    channel_name = await channel_layer.new_channel()
+
+    task = asyncio.ensure_future(
+        send_three_messages_with_delay(channel_name, channel_layer, delay)
+    )
+    await asyncio.wait_for(task, None)
+
+    # the first message should have expired, we should only see the second message and the third
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Second!"
+
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Third!"
+
+    # Make sure there's no third message even out of order
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_name)
+
+
+@pytest.mark.asyncio
+async def test_message_expiry__all_messages_under_expiration_time(channel_layer):
+    expiry = 3
+    delay = 1
+    channel_layer = RedisChannelLayer(expiry=expiry)
+    channel_name = await channel_layer.new_channel()
+
+    task = asyncio.ensure_future(
+        send_three_messages_with_delay(channel_name, channel_layer, delay)
+    )
+    await asyncio.wait_for(task, None)
+
+    # expiry = 3, total delay under 3, all messages there
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "First!"
+
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Second!"
+
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Third!"
+
+
+@pytest.mark.asyncio
+async def test_message_expiry__group_send(channel_layer):
+    expiry = 3
+    delay = 2
+    channel_layer = RedisChannelLayer(expiry=expiry)
+    channel_name = await channel_layer.new_channel()
+
+    await channel_layer.group_add("test-group", channel_name)
+
+    task = asyncio.ensure_future(
+        group_send_three_messages_with_delay("test-group", channel_layer, delay)
+    )
+    await asyncio.wait_for(task, None)
+
+    # the first message should have expired, we should only see the second message and the third
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Second!"
+
+    message = await channel_layer.receive(channel_name)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Third!"
+
+    # Make sure there's no third message even out of order
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_name)
+
+
+@pytest.mark.asyncio
+async def test_message_expiry__group_send__one_channel_expires_message(channel_layer):
+    expiry = 3
+    delay = 1
+
+    channel_layer = RedisChannelLayer(expiry=expiry)
+    channel_1 = await channel_layer.new_channel()
+    channel_2 = await channel_layer.new_channel(prefix="channel_2")
+
+    await channel_layer.group_add("test-group", channel_1)
+    await channel_layer.group_add("test-group", channel_2)
+
+    # Let's give channel_1 one additional message and then sleep
+    await channel_layer.send(channel_1, {"type": "test.message", "text": "Zero!"})
+    await asyncio.sleep(2)
+
+    task = asyncio.ensure_future(
+        group_send_three_messages_with_delay("test-group", channel_layer, delay)
+    )
+    await asyncio.wait_for(task, None)
+
+    # message Zero! was sent about 2 + 1 + 1 seconds ago and it should have expired
+    message = await channel_layer.receive(channel_1)
+    assert message["type"] == "test.message"
+    assert message["text"] == "First!"
+
+    message = await channel_layer.receive(channel_1)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Second!"
+
+    message = await channel_layer.receive(channel_1)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Third!"
+
+    # Make sure there's no fourth message even out of order
+    with pytest.raises(asyncio.TimeoutError):
+        async with async_timeout.timeout(1):
+            await channel_layer.receive(channel_1)
+
+    # channel_2 should receive all three messages from group_send
+    message = await channel_layer.receive(channel_2)
+    assert message["type"] == "test.message"
+    assert message["text"] == "First!"
+
+    # the first message should have expired, we should only see the second message and the third
+    message = await channel_layer.receive(channel_2)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Second!"
+
+    message = await channel_layer.receive(channel_2)
+    assert message["type"] == "test.message"
+    assert message["text"] == "Third!"
+
+
+def test_default_group_key_format():
+    channel_layer = RedisChannelLayer()
+    group_name = channel_layer._group_key("test_group")
+    assert group_name == b"asgi:group:test_group"
+
+
+def test_custom_group_key_format():
+    channel_layer = RedisChannelLayer(prefix="test_prefix")
+    group_name = channel_layer._group_key("test_group")
+    assert group_name == b"test_prefix:group:test_group"
+
+
+def test_receive_buffer_respects_capacity():
+    channel_layer = RedisChannelLayer()
+    buff = channel_layer.receive_buffer["test-group"]
+    for i in range(10000):
+        buff.put_nowait(i)
+
+    capacity = 100
+    assert channel_layer.capacity == capacity
+    assert buff.full() is True
+    assert buff.qsize() == capacity
+    messages = [buff.get_nowait() for _ in range(capacity)]
+    assert list(range(9900, 10000)) == messages


### PR DESCRIPTION
To capitalize on the bit of interest this library seems to have at the moment, I have pushed the internal branch that we have been using that provides limited sentinel support, and switches over to using aioredis pools (necessary as part of the sentinel client).

Even if this doesn't get merged because a pubsub rewrite supersedes it, it might have some value to others. A few things to note:

1. ~~There is no database support when using sentinels. This would be an easy add-on but we don't use internally, instead opting to scale out the number of redis clusters. But it doesn't fit in with the existing config shape.~~
2. ~~There is no sharding support when using sentinels. The config expects a list of tuples corresponding to the sentinel cluster. Again, an easy tweak but not something we use internally.~~
3. The tests have been duplicated from the vanilla redis tests, and don't test any specific sentinel functionality around failover. But in a failover situation, the connections get reaped by the aioredis pool, which triggers other connection cleanup so not entirely sure if that is out of scope for the unit tests.
4. The test suite only provides one sentinel and one redis instance.

