### PR TITLE
Add default to serialize method

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -832,11 +832,20 @@ class RedisChannelLayer(BaseChannelLayer):
 
     ### Serialization ###
 
+    def default_serialize(self, value):
+        """
+        Gets called for objects that can’t otherwise be serialized.
+        It should return a JSON encodable version of the object or raise TypeError.
+
+        It should be overriden when an alternative default serialization is required.
+        """
+        raise TypeError
+
     def serialize(self, message):
         """
         Serializes message to a byte string.
         """
-        value = msgpack.packb(message, use_bin_type=True)
+        value = msgpack.packb(message, use_bin_type=True, default=self.default_serialize)
         if self.crypter:
             value = self.crypter.encrypt(value)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import uuid
 
 import async_timeout
 import pytest
@@ -22,6 +23,15 @@ MULTIPLE_TEST_HOSTS = [
     "redis://localhost:6379/8",
     "redis://localhost:6379/9",
 ]
+
+
+class UUIDRedisChannelLayer(RedisChannelLayer):
+
+    def default_serialize(self, value):
+        if isinstance(value, uuid.UUID):
+            return str(value)
+
+        return super().default_serialize(value)
 
 
 async def send_three_messages_with_delay(channel_name, channel_layer, delay):
@@ -641,3 +651,19 @@ def test_receive_buffer_respects_capacity():
     assert buff.qsize() == capacity
     messages = [buff.get_nowait() for _ in range(capacity)]
     assert list(range(9900, 10000)) == messages
+
+
+def test_default_serialize():
+    channel_layer = RedisChannelLayer()
+    value = uuid.UUID("12345678-1234-5678-1234-567812345678")
+    with pytest.raise(TypeError):
+        channel_layer.default_serialize(value)
+
+    with pytest.raise(TypeError):
+        channel_layer.serialize({"value": value})
+
+    channel_layer = UUIDRedisChannelLayer()
+    packed_message = channel_layer.serialize({"value": value})
+    assert channel_layer.deserialize(packed_message) == {"value": "12345678-1234-5678-1234-567812345678"}
+
+


### PR DESCRIPTION
This is a revised version of #237. Instead of adding an explicit default callbak to `msgpack.packb` a placeholder method is placed.

In this way it can be overriden according to use cases.