### PR TITLE
Fix RuntimeError when modifying in_use map

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -103,8 +103,7 @@ class ConnectionPool:
         """
         Return a connection to the pool.
         """
-        loop = self.in_use[conn]
-        del self.in_use[conn]
+        loop = self.in_use.pop(conn, None)
         if loop is not None:
             conns, _ = self._ensure_loop(loop)
             conns.append(conn)
@@ -114,7 +113,7 @@ class ConnectionPool:
         Handle a connection that produced an error.
         """
         await self._close_conn(conn)
-        del self.in_use[conn]
+        self.in_use.pop(conn, None)
 
     def reset(self):
         """
@@ -143,10 +142,10 @@ class ConnectionPool:
                 await self._close_conn(conn)
             del self.conn_map[loop]
 
-        for k, v in self.in_use.items():
+        for k, v in list(self.in_use.items()):
             if v is loop:
                 await self._close_conn(k)
-                self.in_use[k] = None
+                self.in_use.pop(k, None)
 
     async def close(self):
         """


### PR DESCRIPTION
Python throws a RuntimeError if we try to modify a dictionary while
iterating over a view of its items. We avoid the error by iterating over
a copy of the items in the dictionary.

Also, esnure that the in_use dictionary does not contain empty mappings
by deleting the entry when closing the loop.

fixes #243