### PR TITLE
Fix intermittent ChannelFull test failure

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -436,7 +436,7 @@ async def test_receive_cancel(channel_layer):
     """
     Makes sure we can cancel a receive without blocking
     """
-    channel_layer = RedisChannelLayer(capacity=10)
+    channel_layer = RedisChannelLayer(capacity=20)
     channel = await channel_layer.new_channel()
     delay = 0
     while delay < 0.01:

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -439,7 +439,7 @@ async def test_receive_cancel(channel_layer):
     """
     Makes sure we can cancel a receive without blocking
     """
-    channel_layer = RedisChannelLayer(capacity=10)
+    channel_layer = RedisChannelLayer(capacity=20)
     channel = await channel_layer.new_channel()
     delay = 0
     while delay < 0.01:


### PR DESCRIPTION
Fixes #229

The intermittent failure stemming from `test_receive_cancel` in `test_core` and `test_sentinel` that has capacity set to 10.

I ran those tests multiple times to find out by how much it can go over the capacity, by printing out results in `core.py`. It maxed at 15. I bumped the capacity to 20 for some head-space and ran tests again in a loop. I never got the intermittent ChannelFull exception.