### PR TITLE
Fix linting in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ This package is for Channels 2 projects only.
 Usage
 -----
 
-Set up the channel layer in your Django settings file like so::
+Set up the channel layer in your Django settings file like so:
 
 .. code-block:: python
 
@@ -47,7 +47,7 @@ Set up the channel layer in your Django settings file like so::
         },
     }
 
-Or, you can use the alternate implementation which uses Redis Pub/Sub::
+Or, you can use the alternate implementation which uses Redis Pub/Sub:
 
 .. code-block:: python
 


### PR DESCRIPTION
# Hi there,

In line 37 and 50 there are :: ( two colons ) before the code-block 
Where it should be : ( One Colon )  to properly lint the code.

This pull request fixes this issue.

# Here is a before pic :
 ![before](https://user-images.githubusercontent.com/61817579/147198914-dad03867-1a1d-425d-b4b2-108555b1e173.PNG)
 
 # Here is a after pic : 
![After](https://user-images.githubusercontent.com/61817579/147198999-d5308b8b-f2bb-42cf-a95c-daa5b2358d1e.PNG)