### PR TITLE
Fix list of Redis commands used by `RedisPubSubChannelLayer`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,8 +224,7 @@ Your Redis server must support the following commands:
   ``KEYS``, ``PIPELINE``, ``ZADD``, ``ZCOUNT``, ``ZPOPMIN``, ``ZRANGE``,
   ``ZREM``, ``ZREMRANGEBYSCORE``
 
-* ``RedisPubSubChannelLayer`` uses ``ADD``, ``COPY``, ``FLUSH``, ``GET``,
-  ``PUBLISH``
+* ``RedisPubSubChannelLayer`` uses ``PUBLISH``, ``SUBSCRIBE``, ``UNSUBSCRIBE``
 
 Contributing
 ------------


### PR DESCRIPTION
Followup of https://github.com/django/channels_redis/pull/291 to manually fix the auto-generated list.