### PR TITLE
[Feature] Discard full channels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,13 @@ to 10, and all ``websocket.send!`` channels to 20:
 If you want to enforce a matching order, use an ``OrderedDict`` as the
 argument; channels will then be matched in the order the dict provides them.
 
+``should_auto_discard_full_channels``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When this option is set to ``True`` and a message is sent to a channel that is at its
+maximum capacity (e.g. 100 messages are in a channel whose capacity is 100), the
+*entire channel* will be discarded from its group.
+
 ``symmetric_encryption_keys``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hey there. I'd love to have this option included with Channels Redis, given the challenges some folks have with channels not always being discarded due to whatever other reasons. Thanks for your time!

## Problem

We have an issue where channels are no longer being consumed from, but they linger around anyway. This requires us to support far more channels than we need to.

Ideally we'd figure out how to discard these channels upon clients disconnecting, but even though we call `group_discard` appropriately, the channels don't seem to be discarded.

## Solution

Add an option that, when enabled, discards any at-capacity channels immediately upon sending a message that channel.

## Testing

- [x] Added an automated test
- [x] Tested with our own application code