### PR TITLE
Fix iscoroutine check for pubsub proxied methods

### DIFF
--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -171,6 +171,6 @@ def test_multi_event_loop_garbage_collection(channel_layer):
 @pytest.mark.asyncio
 async def test_proxied_methods_coroutine_check(channel_layer):
     # inspect.iscoroutinefunction does not work for partial functions
-    # below Python 3.8 
+    # below Python 3.8.
     if sys.version_info >= (3, 8):
         assert inspect.iscoroutinefunction(channel_layer.send)

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,5 +1,7 @@
 import asyncio
+import inspect
 import random
+import sys
 
 import async_timeout
 import pytest
@@ -164,3 +166,11 @@ def test_multi_event_loop_garbage_collection(channel_layer):
     assert len(channel_layer._layers.values()) == 0
     async_to_sync(test_send_receive)(channel_layer)
     assert len(channel_layer._layers.values()) == 0
+
+
+@pytest.mark.asyncio
+async def test_proxied_methods_coroutine_check(channel_layer):
+    # inspect.iscoroutinefunction does not work for partial functions
+    # below Python 3.8 
+    if sys.version_info >= (3, 8):
+        assert inspect.iscoroutinefunction(channel_layer.send)


### PR DESCRIPTION
Adjust the proxying approach in `RedisPubSubChannelLayer` to ensure the
proxied methods are properly marked as coroutines according to
`inspect.iscoroutinefunction`. This can be issue during testing when
trying to mock channel layer methods.

The underlying issue is a [Python bug][1] where partial methods are not
fully unwrapped to determine if they are coroutines. The workaround
simply moves the proxy wrapper to a top-level async function, tricking
`inspect.iscoroutinefunction` to correctly detecting the proxied async
methods.

[1]: https://bugs.python.org/issue38364