### PR TITLE
Fix workers support when using Redis PubSub layer

### DIFF
--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -148,7 +148,7 @@ async def test_receive_on_non_owned_general_channel(channel_layer, other_channel
     try:
         # Make sure we get the message on the channels that were in
         async with async_timeout.timeout(1):
-            assert (await receive_task == "message.1")
+            assert await receive_task == "message.1"
     finally:
         receive_task.cancel()
 

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -135,6 +135,7 @@ async def test_receive_on_non_owned_general_channel(channel_layer, other_channel
     Tests receive with general channel that is not owned by the layer
     """
     receive_started = asyncio.Event()
+
     async def receive():
         receive_started.set()
         return await other_channel_layer.receive("test-channel")

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -24,6 +24,17 @@ async def channel_layer():
     await channel_layer.flush()
 
 
+@pytest.fixture()
+@async_generator
+async def other_channel_layer():
+    """
+    Channel layer fixture that flushes automatically.
+    """
+    channel_layer = RedisPubSubChannelLayer(hosts=TEST_HOSTS)
+    await yield_(channel_layer)
+    await channel_layer.flush()
+
+
 @pytest.mark.asyncio
 async def test_send_receive(channel_layer):
     """
@@ -116,6 +127,29 @@ async def test_groups_same_prefix(channel_layer):
         assert (await channel_layer.receive(channel_name1))["type"] == "message.1"
         assert (await channel_layer.receive(channel_name2))["type"] == "message.1"
         assert (await channel_layer.receive(channel_name3))["type"] == "message.1"
+
+
+@pytest.mark.asyncio
+async def test_receive_on_non_owned_general_channel(channel_layer, other_channel_layer):
+    """
+    Tests receive with general channel that is not owned by the layer
+    """
+    receive_started = asyncio.Event()
+    async def receive():
+        receive_started.set()
+        return await other_channel_layer.receive("test-channel")
+
+    receive_task = asyncio.create_task(receive())
+    await receive_started.wait()
+    await asyncio.sleep(0.1)  # Need to give time for "receive" to subscribe
+    await channel_layer.send("test-channel", "message.1")
+
+    try:
+        # Make sure we get the message on the channels that were in
+        async with async_timeout.timeout(1):
+            assert (await receive_task == "message.1")
+    finally:
+        receive_task.cancel()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The new Redis PubSub layer broke support for Channels workers. Add
support for workers by subscribing to non-owned channels instead of
throwing an exception.

fixes #270