### PR TITLE
Deprecate Python 3.6 support, add Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - 3.6
         - 3.7
         - 3.8
         - 3.9
+        - "3.10"
     services:
       redis:
         image: redis

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+Dropped support for Python 3.6.
+
+
 3.3.1 (2021-09-30)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ And then in your channels consumer, you can implement the handler:
 Dependencies
 ------------
 
-Redis >= 5.0 is required for `channels_redis`. Python 3.6 or higher is required.
+Redis >= 5.0 is required for `channels_redis`. Python 3.7 or higher is required.
 
 
 Used commands

--- a/channels_redis/pubsub.py
+++ b/channels_redis/pubsub.py
@@ -1,7 +1,6 @@
 import asyncio
 import functools
 import logging
-import sys
 import types
 import uuid
 
@@ -11,12 +10,6 @@ import msgpack
 from .utils import _consistent_hash
 
 logger = logging.getLogger(__name__)
-
-
-if sys.version_info >= (3, 7):
-    get_running_loop = asyncio.get_running_loop
-else:
-    get_running_loop = asyncio.get_event_loop
 
 
 def _wrap_close(proxy, loop):
@@ -67,7 +60,7 @@ class RedisPubSubChannelLayer:
         return msgpack.unpackb(message)
 
     def _get_layer(self):
-        loop = get_running_loop()
+        loop = asyncio.get_running_loop()
 
         try:
             layer = self._layers[loop]

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         "aioredis~=1.0",
         "msgpack~=1.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}
+    py{37,38,39,310}
     qa
 
 [testenv]


### PR DESCRIPTION
* Deprecate Python 3.6 and remove code to support Python versions < 3.7.
* Add Python 3.10 to tox configuration.