### PR TITLE
Ping redis connection before using it

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -93,6 +93,11 @@ class ConnectionPool:
             conn = await self.create_conn(loop)
             conns.append(conn)
         conn = conns.pop()
+        try:
+            # ping the connection to update `.closed` status
+            await conn.ping()
+        except (BrokenPipeError, aioredis.ConnectionClosedError):
+            pass
         if conn.closed:
             conn = await self.pop(loop=loop)
             return conn


### PR DESCRIPTION
If the redis server closes the connection, we may not know about that
closure until we attempt to use it and get a network or aioredis error.
If we ping-test the connection first, we can catch and reconnect without
causing any application code to receive errors.