### PR TITLE
[3.4.x] Removed obsolete code.

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -199,10 +199,6 @@ class ChannelLock:
             del self.wait_counts[channel]
 
 
-class UnsupportedRedis(Exception):
-    pass
-
-
 class BoundedQueue(asyncio.Queue):
     def put_nowait(self, item):
         if self.full():
@@ -739,41 +735,6 @@ class RedisChannelLayer(BaseChannelLayer):
                         len(channel_names),
                         group,
                     )
-
-    def _map_channel_to_connection(self, channel_names, message):
-        """
-        For a list of channel names, bucket each one to a dict keyed by the
-        connection index
-        Also for each channel create a message specific to that channel, adding
-        the __asgi_channel__ key to the message
-        We also return a mapping from channel names to their corresponding Redis
-        keys, and a mapping of channels to their capacity
-        """
-        connection_to_channels = collections.defaultdict(list)
-        channel_to_message = dict()
-        channel_to_capacity = dict()
-        channel_to_key = dict()
-
-        for channel in channel_names:
-            channel_non_local_name = channel
-            if "!" in channel:
-                message = dict(message.items())
-                message["__asgi_channel__"] = channel
-                channel_non_local_name = self.non_local_name(channel)
-            channel_key = self.prefix + channel_non_local_name
-            idx = self.consistent_hash(channel_non_local_name)
-            connection_to_channels[idx].append(channel_key)
-            channel_to_capacity[channel] = self.get_capacity(channel)
-            channel_to_message[channel] = self.serialize(message)
-            # We build a
-            channel_to_key[channel] = channel_key
-
-        return (
-            connection_to_channels,
-            channel_to_message,
-            channel_to_capacity,
-            channel_to_key,
-        )
 
     def _map_channel_keys_to_connection(self, channel_names, message):
         """


### PR DESCRIPTION
The following are obsolete:

- `channels_redis.core.UnsupportedRedis` since ff8c8e682fc08509bc2eaac7c51f5194b37b549d.
- `channels_redis.core.RedisChannelLayer._map_channel_to_connection()` since 9f05013d91c7a59b7f5515faceec5b604ab9af5a.