### PR TITLE
Used testpaths for pytest configuration.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
-addopts = -p no:django tests/
+addopts = -p no:django
+testpaths = tests
 
 [flake8]
 exclude = venv/*,tox/*,specs/*,build/*


### PR DESCRIPTION
Specifying the `tests` dir in testpaths allows overriding at the
command line. Previously, as part of addopts it couldn't be removed.

For example:

pytest tests/test_pubsub.py

... will now pick up just that once file, rather than the whole
`tests` folder, and that file again.