### PR TITLE
Update CHANGELOG.txt

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -4,10 +4,11 @@
 Version 4.0.0 migrates the underlying Redis library from ``aioredis`` to ``redis-py``.
 (``aioredis`` was retired and moved into ``redis-py``, which will host the ongoing development.)
 
-The API is unchanged. Version 4.0.0 should be compatible with existing Channels 3 projects, as well as Channels 4
+Version 4.0.0 should be compatible with existing Channels 3 projects, as well as Channels 4
 projects.
 
-* Migrated from ``aioredis`` to ``redis-py``.
+* Migrated from ``aioredis`` to ``redis-py``. If you are using dicts in the `hosts` configuration
+  parameter these should now conform to redis Connection <https://redis-py.readthedocs.io/en/v4.3.3/connections.html#redis.connection.Connection>`_.
 
 * Added support for passing kwargs to sentinel connections.
 

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -7,8 +7,9 @@ Version 4.0.0 migrates the underlying Redis library from ``aioredis`` to ``redis
 Version 4.0.0 should be compatible with existing Channels 3 projects, as well as Channels 4
 projects.
 
-* Migrated from ``aioredis`` to ``redis-py``. If you are using dicts in the `hosts` configuration
-  parameter these should now conform to redis Connection <https://redis-py.readthedocs.io/en/v4.3.3/connections.html#redis.connection.Connection>`_.
+* Migrated from ``aioredis`` to ``redis-py``. Specifying hosts as tuples is no longer supported.
+  If hosts are specified as dicts, only the ``address`` key will be taken into account, i.e.
+  a `password`` must be specified inline in the address.
 
 * Added support for passing kwargs to sentinel connections.
 


### PR DESCRIPTION
As is evidenced in 65a05285d512e32607829b45cba5b4093e6003a6 the (configuration) API is not entirely unchanged. In particular, using a tuple in the `address` section of the `hosts` `CONFIG` will now lead to a failure.