### PR TITLE
Allow passing extra connection kwargs with host address

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,13 +65,27 @@ Possible options for ``CONFIG`` are listed below.
 ``hosts``
 ~~~~~~~~~
 
-The server(s) to connect to, as either URIs, ``(host, port)`` tuples, or dicts conforming to `redis Connection <https://redis-py.readthedocs.io/en/v4.3.3/connections.html#redis.connection.Connection>`_.
+The server(s) to connect to.
+Can be either:
+
+- URIs with extra connection kwargs like
+
+.. code-block:: python
+
+    {
+        "address": "redis://localhost:6379",
+        "ssl_cert_reqs": None,
+    }
+
+
+- or ``(host, port)`` tuples
+- or dicts conforming to `redis Connection <https://redis-py.readthedocs.io/en/v4.3.3/connections.html#redis.connection.Connection>`_.
 Defaults to ``redis://localhost:6379``. Pass multiple hosts to enable sharding,
 but note that changing the host list will lose some sharded data.
 
 Sentinel connections require dicts conforming to:
 
-.. code-block::
+.. code-block:: python
 
     {
         "sentinels": [

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -130,7 +130,8 @@ class RedisChannelLayer(BaseChannelLayer):
         host = self.hosts[index]
 
         if "address" in host:
-            return aioredis.ConnectionPool.from_url(host["address"])
+            address = host.pop("address")
+            return aioredis.ConnectionPool.from_url(address, **host)
         elif "master_name" in host:
             sentinels = host.pop("sentinels")
             master_name = host.pop("master_name")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -652,3 +652,19 @@ def test_deserialize():
 
     assert isinstance(deserialized, dict)
     assert deserialized == {"a": True, "b": None, "c": {"d": []}}
+
+
+def test_create_pool_from_url():
+    """
+    Test allowing passing additional parameters to the connection via host
+    configuration.
+    """
+    hosts = [
+        {
+            "address": "rediss://localhost:6379/0",
+            "ssl_cert_reqs": None,
+        }
+    ]
+    channel_layer = RedisChannelLayer(hosts=hosts)
+    pool = channel_layer.create_pool(0)
+    assert "ssl_cert_reqs" in pool.connection_kwargs


### PR DESCRIPTION
This should fix some of the issues with #331 by allowing to pass extra connection arguments with the host configuration.
The specific case that this helps me with is passing the ssl kwargs into the connection as advised by [Heroku redis docs](https://devcenter.heroku.com/articles/connecting-heroku-redis#connecting-in-python)