### PR TITLE
fix: django conf should not be modified

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -11,7 +11,6 @@ import uuid
 
 import msgpack
 from redis import asyncio as aioredis
-from copy import deepcopy
 from channels.exceptions import ChannelFull
 from channels.layers import BaseChannelLayer
 
@@ -132,14 +131,15 @@ class RedisChannelLayer(BaseChannelLayer):
         if "address" in host:
             return aioredis.ConnectionPool.from_url(host["address"])
         elif "master_name" in host:
-            host_kwargs = deepcopy(host)
-            sentinels = host_kwargs.pop("sentinels")
-            master_name = host_kwargs.pop("master_name")
-            sentinel_kwargs = host_kwargs.pop("sentinel_kwargs", None)
+            # copy host dict to prevent original one from being modified
+            host= host.copy()
+            sentinels = host.pop("sentinels")
+            master_name = host.pop("master_name")
+            sentinel_kwargs = host.pop("sentinel_kwargs", None)
             return aioredis.sentinel.SentinelConnectionPool(
                 master_name,
                 aioredis.sentinel.Sentinel(sentinels, sentinel_kwargs=sentinel_kwargs),
-                **host_kwargs
+                **host
             )
         else:
             return aioredis.ConnectionPool(**host)

--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -11,7 +11,7 @@ import uuid
 
 import msgpack
 from redis import asyncio as aioredis
-
+from copy import deepcopy
 from channels.exceptions import ChannelFull
 from channels.layers import BaseChannelLayer
 
@@ -132,13 +132,14 @@ class RedisChannelLayer(BaseChannelLayer):
         if "address" in host:
             return aioredis.ConnectionPool.from_url(host["address"])
         elif "master_name" in host:
-            sentinels = host.pop("sentinels")
-            master_name = host.pop("master_name")
-            sentinel_kwargs = host.pop("sentinel_kwargs", None)
+            host_kwargs = deepcopy(host)
+            sentinels = host_kwargs.pop("sentinels")
+            master_name = host_kwargs.pop("master_name")
+            sentinel_kwargs = host_kwargs.pop("sentinel_kwargs", None)
             return aioredis.sentinel.SentinelConnectionPool(
                 master_name,
                 aioredis.sentinel.Sentinel(sentinels, sentinel_kwargs=sentinel_kwargs),
-                **host
+                **host_kwargs
             )
         else:
             return aioredis.ConnectionPool(**host)


### PR DESCRIPTION
This place is passed by reference, which will cause the configuration to change, and other applications will read the wrong configuration

before this pr:
`
from django.conf import settings
getattr(settings, "CHANNEL_LAYERS", {})
`
result

`{'default': {'BACKEND': 'channels_redis.core.RedisChannelLayer', 'CONFIG': {'hosts': [{'sentinels': [('a.b.c.d', 6379)], 'master_name': 'redis-master', 'db': 0, 'password': 'password', 'sentinel_kwargs': {'password': 'password'}}]}}}`

after channel connection result

`{'default': {'BACKEND': 'channels_redis.core.RedisChannelLayer', 'CONFIG': {'hosts': [{'db': 0, 'password': 'password'}]}}}`

