### PR TITLE
Makes group_discard a noop if channel not in group

### DIFF
--- a/channels_redis/pubsub.py
+++ b/channels_redis/pubsub.py
@@ -223,12 +223,14 @@ class RedisPubSubLoopLayer:
 
     async def group_discard(self, group, channel):
         """
-        Removes the channel from a group.
+        Removes the channel from a group if it is in the group;
+        does nothing otherwise (does not error)
         """
         group_channel = self._get_group_channel_name(group)
-        assert group_channel in self.groups
-        group_channels = self.groups[group_channel]
-        assert channel in group_channels
+        group_channels = self.groups.get(group_channel, set())
+        if channel not in group_channels:
+            return
+
         group_channels.remove(channel)
         if len(group_channels) == 0:
             del self.groups[group_channel]

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -252,3 +252,10 @@ async def test_auto_reconnect(channel_layer):
     with pytest.raises(asyncio.TimeoutError):
         async with async_timeout.timeout(1):
             await channel_layer.receive(channel_name2)
+
+
+@pytest.mark.asyncio
+async def test_discard_before_add(channel_layer):
+    channel_name = await channel_layer.new_channel(prefix="test-channel")
+    # Make sure that we can remove a group before it was ever added without crashing.
+    await channel_layer.group_discard("test-group", channel_name)


### PR DESCRIPTION
Updates `RedisPubSubChannelLayer` to return early if `group_discard` is called with a channel that does not belong to the group.

Closes #343.