### PR TITLE
Pin redis py to 4.3.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,7 @@ jobs:
   tests:
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.7",
     install_requires=[
-        "redis>=4.2.0",
+        "redis~=4.3.5",
         "msgpack~=1.0",
         "asgiref>=3.2.10,<4",
         "channels",


### PR DESCRIPTION
This in practice seems to be the last/most stable version of redis-py for the test suite. GitHub's default is to run for 6 hours which is excessive, if tox hangs and takes longer than 10 minutes it never comes back.

Would make a temporary fix to get proper support/fix for #348 