### PR TITLE
docs: Update README ref to Redis to match package requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ And then in your channels consumer, you can implement the handler:
 Dependencies
 ------------
 
-Redis >= 4.2.0 is required for `channels_redis`. Python 3.7 or higher is required.
+Redis server >= 5.0 is required for `channels_redis`. Python 3.7 or higher is required.
 
 
 Used commands

--- a/README.rst
+++ b/README.rst
@@ -222,7 +222,7 @@ And then in your channels consumer, you can implement the handler:
 Dependencies
 ------------
 
-Redis >= 5.0 is required for `channels_redis`. Python 3.7 or higher is required.
+Redis >= 4.2.0 is required for `channels_redis`. Python 3.7 or higher is required.
 
 
 Used commands


### PR DESCRIPTION
This fixes #350 to update the README redis dependency to match the actual python dependency.

Nice & simple.