### PR TITLE
Refactored Redis connection utilities to share between layers.

### DIFF
--- a/channels_redis/utils.py
+++ b/channels_redis/utils.py
@@ -1,6 +1,8 @@
 import binascii
 import types
 
+from redis import asyncio as aioredis
+
 
 def _consistent_hash(value, ring_size):
     """
@@ -31,3 +33,53 @@ def _wrap_close(proxy, loop):
         return self.close(*args, **kwargs)
 
     loop.close = types.MethodType(_wrapper, loop)
+
+
+def decode_hosts(hosts):
+    """
+    Takes the value of the "hosts" argument and returns
+    a list of kwargs to use for the Redis connection constructor.
+    """
+    # If no hosts were provided, return a default value
+    if not hosts:
+        return [{"address": "redis://localhost:6379"}]
+    # If they provided just a string, scold them.
+    if isinstance(hosts, (str, bytes)):
+        raise ValueError(
+            "You must pass a list of Redis hosts, even if there is only one."
+        )
+
+    # Decode each hosts entry into a kwargs dict
+    result = []
+    for entry in hosts:
+        if isinstance(entry, dict):
+            result.append(entry)
+        elif isinstance(entry, (tuple, list)):
+            result.append({"host": entry[0], "port": entry[1]})
+        else:
+            result.append({"address": entry})
+    return result
+
+
+def create_pool(host):
+    """
+    Takes the value of the "host" argument and returns a suited connection pool to
+    the corresponding redis instance.
+    """
+    # avoid side-effects from modifying host
+    host = host.copy()
+    if "address" in host:
+        address = host.pop("address")
+        return aioredis.ConnectionPool.from_url(address, **host)
+
+    master_name = host.pop("master_name", None)
+    if master_name is not None:
+        sentinels = host.pop("sentinels")
+        sentinel_kwargs = host.pop("sentinel_kwargs", None)
+        return aioredis.sentinel.SentinelConnectionPool(
+            master_name,
+            aioredis.sentinel.Sentinel(sentinels, sentinel_kwargs=sentinel_kwargs),
+            **host
+        )
+
+    return aioredis.ConnectionPool(**host)


### PR DESCRIPTION
Move common methods from core and pubsub layers into utils, adding host parsing also in pubsub layer (see #334 and comment in #335).

This also fixes #331, #337 and #341 by moving the copy mechanism at the top of `create_pool` method.