### PR TITLE
Reenabled Python 3.11 testing.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
-          # Refs #348 - skip Python 3.11 until redis-py >= 4.5.4 (or Python 3.11.3)
-          # - "3.11"
+          - "3.11"
     services:
       redis:
         image: redis


### PR DESCRIPTION
redis-py 4.5.4 was released fixing the issue with PY311. 
Reverts 093471f68f11da1dfa495a76305d1e96c3cda0ad.

Refs #348 