### PR TITLE
Document Redis SSL configs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,9 +65,21 @@ Possible options for ``CONFIG`` are listed below.
 ``hosts``
 ~~~~~~~~~
 
-The server(s) to connect to, as either URIs, ``(host, port)`` tuples, or dicts conforming to `redis Connection <https://redis-py.readthedocs.io/en/v4.3.3/connections.html#redis.connection.Connection>`_.
+The server(s) to connect to, as either URIs, ``(host, port)`` tuples, or dicts conforming to `redis Connection <https://redis-py.readthedocs.io/en/stable/connections.html#async-client>`_.
 Defaults to ``redis://localhost:6379``. Pass multiple hosts to enable sharding,
 but note that changing the host list will lose some sharded data.
+
+SSL connections that are self-signed (ex: Heroku):
+
+.. code-block:: python
+
+{
+    "hosts":[
+        "address": "rediss://user@host:port",  // "REDIS_TLS_URL"
+        "ssl_cert_reqs": None
+    ]
+}
+
 
 Sentinel connections require dicts conforming to:
 


### PR DESCRIPTION
There is ongoing discussion and help in https://github.com/django/channels_redis/issues/235 and https://github.com/django/channels_redis/issues/330 (are there more?) about how to specify extra config for the connections to Redis, particularly SSL related.

The example provided is how we got Heroku to behave with it's self-signed certs on 4.1.0. Hopefully it will be helpful and answer a common question.