### PR TITLE
chore: Cleanup refs to python 3.7

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ And then in your channels consumer, you can implement the handler:
 Dependencies
 ------------
 
-Redis server >= 5.0 is required for `channels-redis`. Python 3.7 or higher is required.
+Redis server >= 5.0 is required for `channels-redis`. Python 3.8 or higher is required.
 
 
 Used commands

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     zip_safe=False,
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "redis>=4.5.3",
         "msgpack~=1.0",


### PR DESCRIPTION
This cleans up the python requires and readme that still referred to python 3.7 after I've removed it from the tests.