### PR TITLE
Add redis to test matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8",
     install_requires=[
-        "redis>=4.5.3",
+        "redis>=4.6",
         "msgpack~=1.0",
         "asgiref>=3.2.10,<4",
         "channels",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
-    py{38,39,310,311,312}
+    py{38,39,310,311,312}-ch{30,40,main}-redis50
+    py311-chmain-redis{45,46,50,main}
     qa
 
 [testenv]
@@ -8,6 +9,13 @@ usedevelop = true
 extras = tests
 commands =
     pytest -v {posargs}
+deps =
+    ch30: channels>=3.0,<3.1
+    ch40: channels>=4.0,<4.1
+    chmain: https://github.com/django/channels/archive/main.tar.gz
+    redis46: redis>=4.6,<4.7
+    redis50: redis>=5.0,<5.1
+    redismain: https://github.com/redis/redis-py/archive/master.tar.gz
 
 [testenv:qa]
 skip_install=true


### PR DESCRIPTION
As discussed on #376 this PR aims to add redis to test matrix.

It also adds channels versions to test matrix in order to ensure compatibility with it.

Redis compatibility is tested only against current stable release of channels while channels compatibility is tested only against current stable release of redis.

<details>
<summary>
During the tests I had to increase minimun redis supported version to 4.6 due to https://github.com/redis/redis-py/issues/2754 which was introduced in the 4.5 branch and fixed in 4.6.
</summary>

<pre>
  File "channels_redis/channels_redis/pubsub.py", line 297, in _do_receiving
    message = await self._pubsub.get_message(
  File "channels_redis/.tox/py310-chmain-redis45/lib/python3.10/site-packages/redis/asyncio/client.py", line 927, in get_message
    response = await self.parse_response(block=(timeout is None), timeout=timeout)
  File "channels_redis/.tox/py310-chmain-redis45/lib/python3.10/site-packages/redis/asyncio/client.py", line 804, in parse_response
    response = await self._execute(
  File "channels_redis/.tox/py310-chmain-redis45/lib/python3.10/site-packages/redis/asyncio/client.py", line 784, in _execute
    return await conn.retry.call_with_retry(
  File "channels_redis/.tox/py310-chmain-redis45/lib/python3.10/site-packages/redis/asyncio/retry.py", line 59, in call_with_retry
    return await do()
  File "channels_redis/.tox/py310-chmain-redis45/lib/python3.10/site-packages/redis/asyncio/client.py", line 785, in <lambda>
    lambda: command(*args, **kwargs),
TypeError: SentinelManagedConnection.read_response() got an unexpected keyword argument 'disconnect_on_error'
</pre>
</details>



This should solve #348 and #366.

