### PR TITLE
support msgpack.packb kwargs

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -151,6 +151,12 @@ class RedisChannelLayer(BaseChannelLayer):
         # a message back into the main queue before its cleanup has completed
         self.receive_clean_locks = ChannelLock()
 
+    def _packing_kwargs(message):
+        """
+        kwargs passed to msgpack.packb
+        """
+        return {'use_bin_type': True}
+
     def create_pool(self, index):
         return create_pool(self.hosts[index])
 
@@ -656,7 +662,7 @@ class RedisChannelLayer(BaseChannelLayer):
         """
         Serializes message to a byte string.
         """
-        value = msgpack.packb(message, use_bin_type=True)
+        value = msgpack.packb(message, **self._packing_kwargs(message))
         if self.crypter:
             value = self.crypter.encrypt(value)
 


### PR DESCRIPTION
The main reason for submitting this PR is to give users the ability to subclass RedisChannelLayer and do sth like: 

```
def default(value):
    if isinstance(value, enum.Enum):
        return value.value
    return value


class ECRedisChannelLayer(RedisChannelLayer):
    """EC stands for "enum-compatible" """
    def _packing_kwargs(self, message):
        return {**super()._packing_kwargs, 'default': default}
```