### PR TITLE
fix: Guarante at most once delivery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.8",
     install_requires=[
+        "aioredlock>=0.7.3,<1",
         "redis>=4.6",
         "msgpack~=1.0",
         "asgiref>=3.2.10,<4",


### PR DESCRIPTION
Addresses #299 

This library (`aioredlock`) Implements the redis [distributed locking algorithm `redlock`](https://redis.io/docs/latest/develop/use/patterns/distributed-locks/)

This should create a distributed lock that prevents other consumers from receiving the message if it has already been picked up