### PR TITLE
Update redis version for tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,8 @@ commands =
 deps =
     ch4: channels>=4.0,<5
     chmain: https://github.com/django/channels/archive/main.tar.gz
-    redis5: redis>=5.0,<6
-    redis6: redis>=6.0,<7
+    redis7: redis>=7.0,<8
+    redis8: redis>=8.0,<9
     redismain: https://github.com/redis/redis-py/archive/master.tar.gz
 
 [testenv:qa]


### PR DESCRIPTION
As suggested in https://github.com/django/channels_redis/issues/422#issuecomment-4620977065