### PR TITLE
Cleanup possible orphan entries in RedisChannelLayer receive buffer

### DIFF
--- a/channels_redis/core.py
+++ b/channels_redis/core.py
@@ -33,7 +33,7 @@ class ChannelLock:
 
     def __init__(self):
         self.locks = collections.defaultdict(asyncio.Lock)
-        self.wait_counts = collections.defaultdict(int)
+        self.wait_counts = collections.Counter()
 
     async def acquire(self, channel):
         """
@@ -60,6 +60,11 @@ class ChannelLock:
 
 
 class BoundedQueue(asyncio.Queue):
+    # Timestamp (time.time()) of the last put_nowait() call. Lets
+    # ChannelLayer tell apart a queue whose consumer
+    # vanished (nothing enqueued in a while) from one that's still in use.
+    last_put = 0.0
+
     def put_nowait(self, item):
         if self.full():
             # see: https://github.com/django/channels_redis/issues/212
@@ -69,7 +74,8 @@ class BoundedQueue(asyncio.Queue):
             # that exceed the channel layer capacity than to continue to
             # malloc() forever
             self.get_nowait()
-        return super(BoundedQueue, self).put_nowait(item)
+        self.last_put = time.time()
+        return super().put_nowait(item)
 
 
 class RedisLoopLayer:
@@ -150,6 +156,11 @@ class RedisChannelLayer(BaseChannelLayer):
         self.receive_buffer = collections.defaultdict(
             functools.partial(BoundedQueue, self.capacity)
         )
+        # Per-channel count of coroutines currently blocked in receive().
+        # A buffer with a live waiter must never be evicted from under it.
+        self.receive_waiters = collections.Counter()
+        # Timestamp of the last stale-buffer sweep (throttled to once/expiry).
+        self._last_eviction = 0.0
         # Detached channel cleanup tasks
         self.receive_cleaners = []
         # Per-channel cleanup locks to prevent a receive starting and moving
@@ -248,6 +259,23 @@ class RedisChannelLayer(BaseChannelLayer):
         connection = self.connection(index)
         await connection.zpopmin(self._backup_channel_name(channel))
 
+    def _evict_stale_buffers(self, now):
+        """
+        Drop process-local receive buffers that no coroutine is waiting on and
+        that are either empty or hold only messages older than `expiry`.
+
+        Prevents unbounded growth of `receive_buffer` when messages are
+        dispatched (in `receive`) to specific channels whose consumer has
+        disconnected: those buffers would otherwise never be drained.
+        """
+        for channel in tuple(self.receive_buffer):  # snapshot: we mutate the dict
+            if channel in self.receive_waiters:
+                # A live receive() is using this buffer; never evict it.
+                continue
+            buffer = self.receive_buffer[channel]
+            if buffer.empty() or (now - buffer.last_put > self.expiry):
+                del self.receive_buffer[channel]
+
     async def receive(self, channel):
         """
         Receive the first message that arrives on the channel.
@@ -265,6 +293,15 @@ class RedisChannelLayer(BaseChannelLayer):
             # Enter receiving section
             loop = asyncio.get_running_loop()
             self.receive_count += 1
+            self.receive_waiters[channel] += 1
+            # Opportunistically evict buffers of vanished consumers.
+            # Throttled to at most once per `expiry` window to keep the
+            # O(n) sweep cheap; the current channel is already a waiter,
+            # so it is safe from eviction here.
+            now = time.time()
+            if now - self._last_eviction > self.expiry:
+                self._last_eviction = now
+                self._evict_stale_buffers(now)
             try:
                 if self.receive_count == 1:
                     # If we're the first coroutine in, create the receive lock!
@@ -363,6 +400,9 @@ class RedisChannelLayer(BaseChannelLayer):
 
             finally:
                 self.receive_count -= 1
+                self.receive_waiters[channel] -= 1
+                if self.receive_waiters[channel] < 1:
+                    del self.receive_waiters[channel]
                 # If we were the last out, drop the receive lock
                 if self.receive_count == 0:
                     assert not self.receive_lock.locked()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import time
 
 import async_timeout
 import pytest
@@ -636,3 +637,68 @@ def test_receive_buffer_respects_capacity():
     assert buff.qsize() == capacity
     messages = [buff.get_nowait() for _ in range(capacity)]
     assert list(range(9900, 10000)) == messages
+
+
+@pytest.mark.asyncio
+async def test_receive_buffer_orphan_is_evicted_after_expiry():
+    """
+    End-to-end reproduction of the receive_buffer leak: `active` and `gone`
+    are two specific channels created from the same layer, so they share the
+    same underlying "real" channel in Redis (same client_prefix). Only
+    `active` is ever received on -- `gone`'s consumer has vanished, as
+    happens e.g. when a client disconnects without Channels calling any
+    cleanup hook for it.
+
+    Without the opportunistic eviction in `receive()`, the message routed to
+    `receive_buffer[gone]` would sit there forever: nothing will ever call
+    `receive(gone)` to drain it, and the dict entry has no other way to go
+    away. This test fails on that unpatched behaviour (the orphan buffer
+    never disappears) and passes once stale, unclaimed buffers are evicted.
+    """
+    expiry = 1
+    channel_layer = RedisChannelLayer(expiry=expiry)
+    try:
+        active = await channel_layer.new_channel()
+        gone = await channel_layer.new_channel()
+
+        # Both messages land on the same shared real-channel key in Redis.
+        await channel_layer.send(gone, {"type": "test.message", "text": "for gone"})
+        await channel_layer.send(active, {"type": "test.message", "text": "for active"})
+
+        assert gone not in channel_layer.receive_buffer
+        # receive(active) pops both messages off Redis (they're on the same
+        # key) and routes the one meant for `gone` into receive_buffer[gone].
+        message = await channel_layer.receive(active)
+        assert message["text"] == "for active"
+        assert gone in channel_layer.receive_buffer  # the leak, caught in the act
+
+        # The orphaned message is now older than `expiry`, i.e. as dead as a
+        # message Redis itself would already have discarded.
+        await asyncio.sleep(expiry + 0.05)
+        await channel_layer.send(active, {"type": "test.message", "text": "again"})
+        await channel_layer.receive(active)  # triggers the opportunistic sweep
+
+        assert gone not in channel_layer.receive_buffer
+    finally:
+        await channel_layer.flush()
+
+
+def test_evict_stale_buffers_removes_empty_buffer_without_waiter():
+    channel_layer = RedisChannelLayer()
+    channel = "specific.xxx!empty"
+    # Auto-vivify an empty buffer, as `receive()`'s `while ... .empty()` check does.
+    assert channel_layer.receive_buffer[channel].empty()
+
+    channel_layer._evict_stale_buffers(time.time())
+
+    assert channel not in channel_layer.receive_buffer
+
+
+def test_evict_stale_buffers_keeps_fresh_non_empty_buffer():
+    channel_layer = RedisChannelLayer()
+    channel = "specific.xxx!fresh"
+    channel_layer.receive_buffer[channel].put_nowait({"type": "test.message"})
+
+    channel_layer._evict_stale_buffers(channel_layer.receive_buffer[channel].last_put)
+
+    assert channel in channel_layer.receive_buffer


### PR DESCRIPTION
When a consumer gets deregistered the normal cleanup mechanism may be blocked by an other consumer holding the receive-lock which may read pending messages from the broker for the first one; these messages will be stored in the `receive_buffer` for the deregistered consumer and never read or evicted.

This PR aims to avoid such cases by tracking queue's last-put time and by evicting those queue which last-put has passed the expiry (which is already done at broker level). This assumes that nothing was reading such messages and thus the queue is just eating memory.

This case was analyzed and implemented with the aid of Claude Code.